### PR TITLE
core: extract shared driver, selection, device-pool + add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ for the kinds of paths PathGennie produces.
 pathgennie/
   core/         Backend-independent driver, selection, progress, device pool,
                 Engine protocol, and a toy Wolfe-Quapp Langevin engine
+  cv/           Data-driven CVs: NumPy featurization + on-the-fly SPIB
+                (learned CV + emergent metastable states; needs PyTorch)
   backends/
     amber/      Device-aware AMBER engine + runner
     gromacs/    Device-aware GROMACS engine + runner
@@ -216,6 +218,17 @@ convergence:
     group_b_resname: MOL
     threshold: 10.0
 ```
+
+## Data-Driven CVs (SPIB)
+
+Instead of a hand-crafted progress variable, PathGennie can learn one on the fly
+with **SPIB** (State Predictive Information Bottleneck, `pathgennie.cv.spib`),
+which jointly learns a low-dimensional CV and an emergent set of metastable
+states from the frames the run visits. `SPIBProgress` bootstraps from a coarse
+geometric CV, buffers the path, retrains periodically (the iterative
+path-learning cycle), and then steers using the learned latent. It is an adaptive
+`ProgressVariable`, so it plugs into the same driver as the built-in metrics.
+Requires the `ml` extra (`pip install -e .[ml]`, i.e. PyTorch).
 
 ## Writing a New Case
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ pathgennie/
                 Engine protocol, and a toy Wolfe-Quapp Langevin engine
   cv/           Data-driven CVs: NumPy featurization + on-the-fly SPIB
                 (learned CV + emergent metastable states; needs PyTorch)
+  sampling/     Enhanced-sampling stage contract (PathEnsemble + SamplingStage)
+                for downstream weighted ensemble / OPES
   backends/
     amber/      Device-aware AMBER engine + runner
     gromacs/    Device-aware GROMACS engine + runner
@@ -159,6 +161,10 @@ Each case is driven by an `input.yaml` with four main parts:
   swarm across), `workers_per_device` (concurrent segments per GPU; replaces the
   legacy `tau1_workers`), and `seed` (master RNG seed for the selection and
   velocity draws).
+  Goal key: `profile` (`discovery` for fast candidate paths with ultrashort,
+  greedy, geometric-CV trajectories — the original regime; `sampling` for longer
+  trajectories, a learned CV, and a downstream enhanced-sampling stage). Profile
+  values are defaults; any explicit `pathgennie` key overrides them.
 - `projection`: Python module and function that map coordinates to a
   collective-variable vector.
 - `convergence`: Python module and function that decide when the generated path

--- a/README.md
+++ b/README.md
@@ -48,10 +48,15 @@ for the kinds of paths PathGennie produces.
 
 ```text
 pathgennie/
+  core/         Backend-independent driver, selection, progress, device pool,
+                Engine protocol, and a toy Wolfe-Quapp Langevin engine
   backends/
-    amber/      Generic AMBER runner and utilities
-    gromacs/    Generic GROMACS runner and utilities
-    openmm/     OpenMM runner and in-process PathGennie MD engine
+    amber/      Device-aware AMBER engine + runner
+    gromacs/    Device-aware GROMACS engine + runner
+    openmm/     OpenMM in-process engine + runner
+tests/          pytest suite (selection, CV, I/O, OpenMM, device dispatch)
+benchmarks/
+  scaling.py    Device-pool scaling benchmark
 examples/
   alanine_dipeptide/
   CLN025/
@@ -148,6 +153,10 @@ Each case is driven by an `input.yaml` with four main parts:
   settings.
 - `pathgennie`: adaptive sampling settings such as `mode`, `tau1_steps`,
   `tau2_steps`, `max_trial`, `max_cycle`, `sigma`, and `temperature`.
+  Multi-GPU / reproducibility keys: `devices` (list of GPU indices to spread the
+  swarm across), `workers_per_device` (concurrent segments per GPU; replaces the
+  legacy `tau1_workers`), and `seed` (master RNG seed for the selection and
+  velocity draws).
 - `projection`: Python module and function that map coordinates to a
   collective-variable vector.
 - `convergence`: Python module and function that decide when the generated path
@@ -186,7 +195,9 @@ pathgennie:
     tau1_steps: 5
     tau2_steps: 10
     max_trial: 10
-    tau1_workers: 10
+    devices: [0, 1, 2, 3]   # spread the 10 samplers across 4 GPUs
+    workers_per_device: 1
+    seed: 12345             # reproducible selection / velocity draws
     max_cycle: 5000
     save_freq: 2
     sigma: 0.25

--- a/benchmarks/scaling.py
+++ b/benchmarks/scaling.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+"""Measure how the PathGennie swarm scales across devices.
+
+The multi-GPU win comes from the :class:`~pathgennie.core.parallel.ThreadDevicePool`
+spreading the ``N`` per-cycle sampler segments across GPUs.  Real MD segments
+spend their wall-time inside ``pmemd.cuda`` / ``gmx mdrun`` / an OpenMM kernel,
+i.e. outside the Python GIL, so threads genuinely overlap.
+
+This script reproduces that with a ``SleepEngine`` whose ``run_segment`` sleeps
+for a fixed time (GIL released), modelling a GPU segment of known cost.  It then
+runs the *real* core driver for a fixed number of cycles with 1, 2, 4, ...
+simulated devices and reports cycles/second and speedup, so the dispatch
+overhead of the executor itself can be verified to be small.
+
+To benchmark a real backend instead, point ``--case`` at an ``input.yaml`` and
+set ``pathgennie.devices`` in it; this harness then just times that run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+import threading
+import time
+
+import numpy as np
+
+from pathgennie.core.driver import PathGennieDriver
+from pathgennie.core.parallel import ThreadDevicePool
+from pathgennie.core.progress import EscapeMetric
+
+
+class SleepEngine:
+    """Engine whose segments cost a fixed wall-time (models a GPU MD segment)."""
+
+    def __init__(self, segment_seconds: float = 0.01):
+        self.segment_seconds = float(segment_seconds)
+        self._counter = itertools.count()
+        self._lock = threading.Lock()
+        self._cache: dict[int, np.ndarray] = {}
+
+    def _store(self, pos):
+        with self._lock:
+            h = next(self._counter)
+        self._cache[h] = np.asarray(pos, dtype=float).copy()
+        return h
+
+    def create_state(self, pos):
+        return self._store(pos)
+
+    def clone_anchor(self, handle):
+        return self._store(self._cache[handle])
+
+    def run_segment(self, handle, n_steps, *, randomize_velocities, seed, device=None):
+        time.sleep(self.segment_seconds)  # GIL released, like a real MD call
+        rng = np.random.default_rng(seed)
+        pos = self._cache[handle] + 0.01 * rng.standard_normal(3)
+        return self._store(pos)
+
+    def get_coords(self, handle):
+        return self._cache[handle].reshape(1, 3)
+
+    def release(self, handle):
+        self._cache.pop(handle, None)
+
+
+def benchmark(n_devices_list, *, max_trial, max_cycle, segment_seconds):
+    print(f"max_trial={max_trial}  max_cycle={max_cycle}  segment={segment_seconds*1e3:.1f} ms\n")
+    print(f"{'devices':>8} {'wall (s)':>10} {'cycles/s':>10} {'speedup':>9}")
+    baseline = None
+    for g in n_devices_list:
+        engine = SleepEngine(segment_seconds)
+        initial = engine.create_state(np.zeros(3))
+        progress = EscapeMetric(lambda c: np.array([c[0, 0]]), start_cv=np.array([0.0]), escape_metric="cv0")
+        driver = PathGennieDriver(
+            engine, progress, convergence_fn=lambda c: False,
+            executor=ThreadDevicePool(devices=list(range(g))),
+            sigma=0.1, seed=0, verbosity=0,
+        )
+        t0 = time.perf_counter()
+        driver.run(initial, tau1=1, tau2=1, max_trial=max_trial, max_cycle=max_cycle, save_freq=max_cycle)
+        wall = time.perf_counter() - t0
+        baseline = baseline or wall
+        print(f"{g:>8} {wall:>10.3f} {max_cycle / wall:>10.2f} {baseline / wall:>8.2f}x")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--devices", type=int, nargs="+", default=[1, 2, 4, 8])
+    ap.add_argument("--max-trial", type=int, default=16)
+    ap.add_argument("--max-cycle", type=int, default=20)
+    ap.add_argument("--segment-ms", type=float, default=10.0)
+    args = ap.parse_args()
+    benchmark(args.devices, max_trial=args.max_trial, max_cycle=args.max_cycle,
+              segment_seconds=args.segment_ms / 1000.0)
+
+
+if __name__ == "__main__":
+    main()

--- a/pathgennie/backends/amber/__init__.py
+++ b/pathgennie/backends/amber/__init__.py
@@ -2,15 +2,20 @@
 
 from typing import TYPE_CHECKING
 
-__all__ = ["GenericAmberEngine", "GenericPathGennieAmber", "run"]
+__all__ = ["CoreAmberEngine", "run"]
 
 if TYPE_CHECKING:
-    from .pg_amber import GenericAmberEngine, GenericPathGennieAmber, run
+    from .engine import CoreAmberEngine
+    from .pg_amber import run
 
 
 def __getattr__(name: str):
-    if name in __all__:
+    if name == "CoreAmberEngine":
+        from .engine import CoreAmberEngine
+
+        return CoreAmberEngine
+    if name == "run":
         from . import pg_amber
 
-        return getattr(pg_amber, name)
+        return pg_amber.run
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/pathgennie/backends/amber/engine.py
+++ b/pathgennie/backends/amber/engine.py
@@ -1,0 +1,133 @@
+"""Device-aware AMBER engine adapter for the PathGennie core driver.
+
+Implements the :class:`pathgennie.core.engine.Engine` protocol by shelling out to
+``pmemd.cuda``/``sander`` per segment.  Two problems in the original
+``GenericPathGennieAmber`` are fixed here:
+
+* **No multi-GPU:** the old ``ThreadPoolExecutor`` launched every worker with the
+  inherited environment, so all trials landed on GPU 0.  ``run_segment`` now sets
+  ``CUDA_VISIBLE_DEVICES`` to the device the executor assigned, so a swarm spreads
+  across all GPUs (``subprocess.run`` releases the GIL, so threads genuinely run
+  concurrently).
+* **Scratch races:** trials wrote files with colliding names into one directory.
+  Each segment now gets a unique, per-device scratch subdirectory and a unique
+  file stem.
+
+A *handle* is an absolute path to an AMBER restart (``rst7``) file.
+"""
+
+from __future__ import annotations
+
+import itertools
+import os
+import subprocess
+import threading
+import uuid
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+
+from .utils import read_rst7_coords, write_mdin
+
+__all__ = ["CoreAmberEngine"]
+
+
+class CoreAmberEngine:
+    def __init__(
+        self,
+        *,
+        topology: Path,
+        executable: Path,
+        scratch_dir: Path,
+        temperature: float,
+        mdin_controls: dict,
+        extra_mdin_text: str = "",
+        command_prefix: Optional[list] = None,
+    ):
+        self.topology = str(topology)
+        self.exe = str(executable)
+        self.scratch_dir = Path(scratch_dir)
+        self.scratch_dir.mkdir(parents=True, exist_ok=True)
+        self.temperature = float(temperature)
+        self.mdin_controls = mdin_controls
+        self.extra_mdin_text = extra_mdin_text
+        self.command_prefix = command_prefix or []
+        self._counter = itertools.count()
+        self._lock = threading.Lock()
+
+    def _uid(self) -> str:
+        with self._lock:
+            n = next(self._counter)
+        return f"{n}_{uuid.uuid4().hex[:8]}"
+
+    def _device_dir(self, device: Optional[int]) -> Path:
+        name = "dev_cpu" if device is None else f"dev{device}"
+        path = self.scratch_dir / name
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def clone_anchor(self, handle):
+        src = Path(handle)
+        dst = self.scratch_dir / f"anchor_{self._uid()}.rst7"
+        dst.write_bytes(src.read_bytes())
+        return str(dst)
+
+    def run_segment(self, handle, n_steps, *, randomize_velocities, seed, device=None):
+        workdir = self._device_dir(device)
+        stem = f"seg_{self._uid()}"
+        mdin = workdir / f"{stem}.mdin"
+        out_rst = workdir / f"{stem}.rst7"
+        write_mdin(
+            mdin,
+            int(n_steps),
+            self.temperature,
+            self.mdin_controls,
+            continue_velocities=not randomize_velocities,
+            random_seed=int(seed),
+            extra_text=self.extra_mdin_text,
+        )
+        cmd = [
+            *self.command_prefix, self.exe, "-O",
+            "-i", str(mdin),
+            "-p", self.topology,
+            "-c", str(handle),
+            "-r", str(out_rst),
+            "-o", str(workdir / f"{stem}.out"),
+            "-inf", str(workdir / f"{stem}.mdinfo"),
+        ]
+        if self.mdin_controls.get("ntwx", 0):
+            cmd.extend(["-x", str(workdir / f"{stem}.nc")])
+
+        env = os.environ.copy()
+        if device is not None:
+            env["CUDA_VISIBLE_DEVICES"] = str(device)
+
+        try:
+            subprocess.run(cmd, check=True, capture_output=True, text=True, env=env)
+        except subprocess.CalledProcessError as exc:
+            message = [
+                f"AMBER segment failed with exit code {exc.returncode}.",
+                "Command: " + " ".join(cmd),
+            ]
+            if exc.stdout:
+                message.append("stdout:\n" + exc.stdout[-4000:])
+            if exc.stderr:
+                message.append("stderr:\n" + exc.stderr[-4000:])
+            raise RuntimeError("\n".join(message)) from exc
+        return str(out_rst)
+
+    def get_coords(self, handle):
+        coords = read_rst7_coords(handle)
+        if not np.all(np.isfinite(coords)):
+            raise ValueError(f"AMBER segment produced non-finite coordinates: {handle}")
+        return coords
+
+    def release(self, handle):
+        path = Path(handle)
+        stem = path.with_suffix("")
+        for sibling in path.parent.glob(stem.name + ".*"):
+            try:
+                sibling.unlink()
+            except OSError:
+                pass

--- a/pathgennie/backends/amber/pg_amber.py
+++ b/pathgennie/backends/amber/pg_amber.py
@@ -1,27 +1,27 @@
 #!/usr/bin/env python
-"""Generic PathGennie Amber runner driven by a case-local input.yaml."""
+"""Generic PathGennie Amber runner driven by a case-local input.yaml.
+
+The adaptive cycle now lives in :mod:`pathgennie.core`; this module only loads
+the case configuration, builds a device-aware :class:`CoreAmberEngine`, and runs
+the shared :class:`~pathgennie.core.driver.PathGennieDriver` over a device pool so
+the swarm spreads across all configured GPUs.
+"""
 
 from __future__ import annotations
 
 import argparse
 import os
-import random
 import shutil
-import subprocess
-from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import numpy as np
 import yaml
 
-try:
-    from tqdm.auto import trange  # type: ignore
-except ModuleNotFoundError:
+from pathgennie.core.driver import PathGennieDriver
+from pathgennie.core.parallel import ThreadDevicePool
+from pathgennie.core.progress import EscapeMetric, TargetMetric
 
-    def trange(*args, **kwargs):
-        return range(*args)
-
-
+from .engine import CoreAmberEngine
 from .utils import (
     default_mdin_controls,
     enrich_args,
@@ -30,216 +30,9 @@ from .utils import (
     read_rst7_coords,
     resolve_case_path,
     wrap_frames_pbc,
-    write_mdin,
     write_metrics_csv,
     write_trajectory,
 )
-
-RNG = random.SystemRandom()
-
-
-class GenericAmberEngine:
-    def __init__(
-        self,
-        *,
-        topology: Path,
-        executable: Path,
-        scratch_dir: Path,
-        tau1_steps: int,
-        tau2_steps: int,
-        temperature: float,
-        mdin_controls: dict[str, object],
-        extra_mdin_text: str = "",
-        command_prefix: list[str] | None = None,
-    ):
-        self.topology = str(topology)
-        self.exe = str(executable)
-        self.scratch_dir = scratch_dir
-        self.scratch_dir.mkdir(parents=True, exist_ok=True)
-        self.tau1_steps = int(tau1_steps)
-        self.tau2_steps = int(tau2_steps)
-        self.temperature = float(temperature)
-        self.mdin_controls = mdin_controls
-        self.extra_mdin_text = extra_mdin_text
-        self.command_prefix = command_prefix or []
-
-    def state_path(self, path: str | Path) -> Path:
-        path = Path(path)
-        if path.is_absolute():
-            return path
-        scratch_path = self.scratch_dir / path
-        if scratch_path.exists():
-            return scratch_path
-        if path.exists():
-            return path
-        return scratch_path
-
-    def copy_state(self, src, dst):
-        dst_path = Path(dst)
-        if not dst_path.is_absolute():
-            dst_path = self.scratch_dir / dst_path
-        shutil.copy(self.state_path(src), dst_path)
-
-    def run_segment(self, input_rst, output_prefix):
-        output_name = Path(output_prefix).name
-        is_tau2 = output_name.startswith("tau2_")
-        output_prefix = self.scratch_dir / output_name
-        out_rst = output_prefix.with_suffix(".rst7")
-        mdin = self.scratch_dir / f"{output_name}.mdin"
-        write_mdin(
-            mdin,
-            self.tau2_steps if is_tau2 else self.tau1_steps,
-            self.temperature,
-            self.mdin_controls,
-            continue_velocities=is_tau2,
-            random_seed=RNG.randint(1, 2_000_000_000),
-            extra_text=self.extra_mdin_text,
-        )
-
-        cmd = [
-            *self.command_prefix,
-            self.exe,
-            "-O",
-            "-i",
-            str(mdin),
-            "-p",
-            self.topology,
-            "-c",
-            str(self.state_path(input_rst)),
-            "-r",
-            str(out_rst),
-            "-o",
-            str(output_prefix.with_suffix(".out")),
-            "-inf",
-            str(output_prefix.with_suffix(".mdinfo")),
-        ]
-        if self.mdin_controls.get("ntwx", 0):
-            cmd.extend(["-x", str(output_prefix.with_suffix(".nc"))])
-        subprocess.run(cmd, check=True, capture_output=True, text=True)
-        return str(out_rst)
-
-    def load_coords(self, rst):
-        return read_rst7_coords(self.state_path(rst))
-
-
-class GenericPathGennieAmber:
-    def __init__(
-        self,
-        *,
-        engine,
-        projection_fn,
-        convergence_fn,
-        sigma=0.1,
-        mode="escape",
-        target_projection=None,
-        projection_args=None,
-        convergence_args=None,
-        tau1_workers=1,
-        escape_metric="cv0",
-        reject_worse_tau2=False,
-        reject_worse_anchor=False,
-    ):
-        self.engine = engine
-        self.proj_fn = projection_fn
-        self.conv_fn = convergence_fn
-        self.mode = mode
-        self.sigma = sigma
-        self.target = target_projection
-        self.proj_args = projection_args or {}
-        self.conv_args = convergence_args or {}
-        self.tau1_workers = max(1, int(tau1_workers))
-        self.escape_metric = escape_metric
-        self.reject_worse_tau2 = bool(reject_worse_tau2)
-        self.reject_worse_anchor = bool(reject_worse_anchor)
-
-    def metric(self, cv, start_proj):
-        if self.mode == "escape":
-            if self.escape_metric == "distance_from_start":
-                return np.linalg.norm(cv - start_proj)
-            return float(cv[0])
-        return -np.linalg.norm(cv - self.target)
-
-    def run(self, initial_restart, max_trial=20, max_cycle=1000, save_freq=10):
-        anchor_rst = "anchor.rst7"
-        self.engine.copy_state(initial_restart, anchor_rst)
-        start_pos = self.engine.load_coords(anchor_rst)
-        start_proj = self.proj_fn(start_pos, **self.proj_args)
-        anchor_pos = start_pos
-        anchor_cv = start_proj
-        anchor_metric = self.metric(anchor_cv, start_proj)
-
-        trajectory = []
-        metric_history = []
-
-        def run_trial(cycle, trial):
-            trial_input = f"trial_{trial}.rst7"
-            self.engine.copy_state(anchor_rst, trial_input)
-            tau1_rst = self.engine.run_segment(trial_input, f"tau1_{cycle}_{trial}")
-            pos = self.engine.load_coords(tau1_rst)
-            cv = self.proj_fn(pos, **self.proj_args)
-            return {"rst": tau1_rst, "metric": self.metric(cv, start_proj), "cv": cv}
-
-        for cycle in trange(max_cycle):
-            previous_anchor_rst = anchor_rst
-            workers = min(self.tau1_workers, max_trial)
-            if workers == 1:
-                trials = [run_trial(cycle, trial) for trial in range(max_trial)]
-            else:
-                with ThreadPoolExecutor(max_workers=workers) as executor:
-                    trials = list(executor.map(lambda trial: run_trial(cycle, trial), range(max_trial)))
-
-            metrics = np.array([trial["metric"] for trial in trials])
-            mmin = metrics.min()
-            mmax = metrics.max()
-            if abs(mmax - mmin) < 1e-12:
-                probs = np.ones(len(metrics)) / len(metrics)
-            else:
-                scaled = (metrics - mmin) / (mmax - mmin)
-                weights = np.exp((scaled - 1.0) / self.sigma)
-                probs = weights / weights.sum()
-
-            chosen = trials[np.random.choice(len(trials), p=probs)]
-            tau2_rst = self.engine.run_segment(chosen["rst"], f"tau2_{cycle}")
-            tau2_pos = self.engine.load_coords(tau2_rst)
-            tau2_cv = self.proj_fn(tau2_pos, **self.proj_args)
-            tau2_metric = self.metric(tau2_cv, start_proj)
-
-            if self.reject_worse_tau2 and tau2_metric < chosen["metric"]:
-                anchor_rst = chosen["rst"]
-                pos = self.engine.load_coords(anchor_rst)
-                cv = chosen["cv"]
-                metric = chosen["metric"]
-                print(f"Cycle {cycle}: rejected tau2 metric={tau2_metric:.4f}; kept tau1 metric={metric:.4f}, CV={cv}")
-            else:
-                anchor_rst = tau2_rst
-                pos = tau2_pos
-                cv = tau2_cv
-                metric = tau2_metric
-
-            if self.reject_worse_anchor and metric < anchor_metric:
-                print(
-                    f"Cycle {cycle}: rejected candidate metric={metric:.4f}; "
-                    f"kept anchor metric={anchor_metric:.4f}, CV={anchor_cv}"
-                )
-                anchor_rst = previous_anchor_rst
-                pos = anchor_pos
-                cv = anchor_cv
-                metric = anchor_metric
-            else:
-                anchor_pos = pos
-                anchor_cv = cv
-                anchor_metric = metric
-            metric_history.append(metric)
-
-            if cycle % save_freq == 0:
-                print(f"Cycle {cycle}: metric={metric:.4f}, CV={cv}")
-                trajectory.append(pos.copy())
-
-            if self.conv_fn(pos, **self.conv_args):
-                print(f"Converged at cycle {cycle}")
-                break
-
-        return np.asarray(trajectory), np.asarray(metric_history)
 
 
 def run(case_dir: Path, config_name: str = "input.yaml") -> None:
@@ -284,26 +77,6 @@ def run(case_dir: Path, config_name: str = "input.yaml") -> None:
             *[str(arg) for arg in amber_cfg.get("mpi_launcher_args", [])],
         ]
 
-    write_mdin(
-        workdir / "tau1.mdin",
-        pg_cfg["tau1_steps"],
-        temperature,
-        mdin_controls,
-        continue_velocities=False,
-        random_seed=-1,
-        extra_text=extra_mdin_text,
-    )
-    write_mdin(
-        workdir / "tau2.mdin",
-        pg_cfg["tau2_steps"],
-        temperature,
-        mdin_controls,
-        continue_velocities=True,
-        random_seed=-1,
-        extra_text=extra_mdin_text,
-    )
-    print(f"Using generated Amber mdin files: {workdir / 'tau1.mdin'} and {workdir / 'tau2.mdin'}")
-
     proj_fn = load_function(case_dir, cfg["projection"]["module"], cfg["projection"]["function"])
     conv_fn = load_function(case_dir, cfg["convergence"]["module"], cfg["convergence"]["function"])
 
@@ -316,46 +89,54 @@ def run(case_dir: Path, config_name: str = "input.yaml") -> None:
     projection_args = enrich_args(projection_args, topology_info)
     convergence_args = enrich_args(convergence_args, topology_info)
 
-    initial_cv = proj_fn(read_rst7_coords(initial_restart), **projection_args)
-    print(f"Initial CV: {initial_cv}")
+    start_coords = read_rst7_coords(initial_restart)
+    start_cv = np.asarray(proj_fn(start_coords, **projection_args), dtype=float)
+    print(f"Initial CV: {start_cv}")
 
     mode = pg_cfg.get("mode", "escape")
-    target_projection = None
     if mode == "target":
         if "target_projection" not in pg_cfg:
             raise ValueError("pathgennie.mode is 'target', but pathgennie.target_projection is missing")
-        target_projection = np.asarray(pg_cfg["target_projection"], dtype=float)
-        if target_projection.ndim == 0:
-            target_projection = target_projection.reshape(1)
+        target_projection = np.asarray(pg_cfg["target_projection"], dtype=float).reshape(-1)
+        progress = TargetMetric(proj_fn, target_projection, projection_args=projection_args)
+    else:
+        progress = EscapeMetric(
+            proj_fn, start_cv, projection_args=projection_args,
+            escape_metric=pg_cfg.get("escape_metric", "cv0"),
+        )
 
-    engine = GenericAmberEngine(
+    def convergence(coords: np.ndarray) -> bool:
+        return bool(conv_fn(coords, **convergence_args))
+
+    engine = CoreAmberEngine(
         topology=topology,
         executable=executable,
         scratch_dir=scratch_dir,
-        tau1_steps=pg_cfg["tau1_steps"],
-        tau2_steps=pg_cfg["tau2_steps"],
         temperature=temperature,
         mdin_controls=mdin_controls,
         extra_mdin_text=extra_mdin_text,
         command_prefix=command_prefix,
     )
-    runner = GenericPathGennieAmber(
-        engine=engine,
-        projection_fn=proj_fn,
-        convergence_fn=conv_fn,
+
+    # Device pool: `devices` lists GPU indices; falls back to legacy tau1_workers.
+    devices = pg_cfg.get("devices", amber_cfg.get("devices"))
+    workers_per_device = int(pg_cfg.get("workers_per_device", pg_cfg.get("tau1_workers", 1)))
+    executor = ThreadDevicePool(devices=devices, workers_per_device=workers_per_device)
+
+    driver = PathGennieDriver(
+        engine, progress, convergence,
+        executor=executor,
         sigma=pg_cfg["sigma"],
-        mode=mode,
-        target_projection=target_projection,
-        projection_args=projection_args,
-        convergence_args=convergence_args,
-        tau1_workers=pg_cfg.get("tau1_workers", 1),
-        escape_metric=pg_cfg.get("escape_metric", "cv0"),
+        seed=pg_cfg.get("seed"),
         reject_worse_tau2=pg_cfg.get("reject_worse_tau2", False),
         reject_worse_anchor=pg_cfg.get("reject_worse_anchor", False),
+        verbosity=pg_cfg.get("verbosity", 1),
     )
 
-    traj, metrics = runner.run(
-        initial_restart=str(initial_restart),
+    traj, metrics = driver.run(
+        str(initial_restart),
+        tau1=pg_cfg["tau1_steps"],
+        tau2=pg_cfg["tau2_steps"],
         max_trial=pg_cfg["max_trial"],
         max_cycle=pg_cfg["max_cycle"],
         save_freq=pg_cfg.get("save_freq", 10),

--- a/pathgennie/backends/amber/pg_amber.py
+++ b/pathgennie/backends/amber/pg_amber.py
@@ -20,6 +20,7 @@ import yaml
 from pathgennie.core.driver import PathGennieDriver
 from pathgennie.core.parallel import ThreadDevicePool
 from pathgennie.core.progress import EscapeMetric, TargetMetric
+from pathgennie.core.strategy import resolve_profile
 
 from .engine import CoreAmberEngine
 from .utils import (
@@ -49,7 +50,7 @@ def run(case_dir: Path, config_name: str = "input.yaml") -> None:
     output_dir.mkdir(parents=True, exist_ok=True)
 
     amber_cfg = cfg["amber"]
-    pg_cfg = cfg["pathgennie"]
+    pg_cfg = resolve_profile(cfg["pathgennie"])
     topology = resolve_case_path(case_dir, amber_cfg["topology"])
     initial_restart = resolve_case_path(case_dir, amber_cfg["initial_restart"])
     executable = Path(amber_cfg["executable"]).expanduser()

--- a/pathgennie/backends/gromacs/__init__.py
+++ b/pathgennie/backends/gromacs/__init__.py
@@ -2,10 +2,10 @@
 
 from typing import TYPE_CHECKING
 
-__all__ = ["GenericGromacsEngine", "GenericPathGennieGromacs", "run"]
+__all__ = ["CoreGromacsEngine", "run"]
 
 if TYPE_CHECKING:
-    from .pg_gmx import GenericGromacsEngine, GenericPathGennieGromacs, run
+    from .pg_gmx import CoreGromacsEngine, run
 
 
 def __getattr__(name: str):

--- a/pathgennie/backends/gromacs/pg_gmx.py
+++ b/pathgennie/backends/gromacs/pg_gmx.py
@@ -1,26 +1,32 @@
 #!/usr/bin/env python
-"""Generic PathGennie GROMACS runner driven by a case-local input.yaml."""
+"""Generic PathGennie GROMACS runner driven by a case-local input.yaml.
+
+The adaptive cycle lives in :mod:`pathgennie.core`; this module loads the case
+configuration, builds a device-aware :class:`CoreGromacsEngine`, and runs the
+shared :class:`~pathgennie.core.driver.PathGennieDriver` over a device pool so the
+swarm spreads across all configured GPUs (each segment exports
+``CUDA_VISIBLE_DEVICES`` for its assigned device and uses an isolated scratch
+subdirectory).
+"""
 
 from __future__ import annotations
 
 import argparse
+import itertools
 import os
 import random
 import shutil
 import subprocess
-from concurrent.futures import ThreadPoolExecutor
+import threading
+import uuid
 from pathlib import Path
 
 import numpy as np
 import yaml
 
-try:
-    from tqdm.auto import trange  # type: ignore
-except ModuleNotFoundError:
-
-    def trange(*args, **kwargs):
-        return range(*args)
-
+from pathgennie.core.driver import PathGennieDriver
+from pathgennie.core.parallel import ThreadDevicePool
+from pathgennie.core.progress import EscapeMetric, TargetMetric
 
 from .utils import (
     enrich_args,
@@ -35,23 +41,8 @@ from .utils import (
 RNG = random.SystemRandom()
 
 IGNORED_AMBER_MDP_KEYS = {
-    "cut",
-    "gamma-ln",
-    "igb",
-    "imin",
-    "ioutfm",
-    "irest",
-    "ntb",
-    "ntc",
-    "ntf",
-    "ntp",
-    "ntpr",
-    "ntwx",
-    "ntwr",
-    "ntx",
-    "ntxo",
-    "temp0",
-    "tempi",
+    "cut", "gamma-ln", "igb", "imin", "ioutfm", "irest", "ntb", "ntc", "ntf",
+    "ntp", "ntpr", "ntwx", "ntwr", "ntx", "ntxo", "temp0", "tempi",
 }
 
 
@@ -138,21 +129,19 @@ def split_grompp_only_args(
     return grompp_args, remaining_mdrun_args
 
 
-class GromacsState:
-    def __init__(self, gro: Path, cpt: Path | None = None):
-        self.gro = gro
-        self.cpt = cpt if cpt is not None and cpt.exists() else None
+class CoreGromacsEngine:
+    """Device-aware GROMACS engine implementing the core Engine protocol.
 
+    A *handle* is the path to a ``.gro`` structure; the matching checkpoint is the
+    sibling ``.cpt`` (carried so tau2 runners can continue velocities).
+    """
 
-class GenericGromacsEngine:
     def __init__(
         self,
         *,
         topology: Path,
         executable: Path,
         scratch_dir: Path,
-        tau1_steps: int,
-        tau2_steps: int,
         temperature: float,
         mdp_controls: dict[str, object],
         maxwarn: int = 1,
@@ -161,112 +150,90 @@ class GenericGromacsEngine:
     ):
         self.topology = str(topology)
         self.exe = str(executable)
-        self.scratch_dir = scratch_dir
+        self.scratch_dir = Path(scratch_dir)
         self.scratch_dir.mkdir(parents=True, exist_ok=True)
-        self.tau1_steps = int(tau1_steps)
-        self.tau2_steps = int(tau2_steps)
         self.temperature = float(temperature)
         self.mdp_controls = mdp_controls
         self.maxwarn = int(maxwarn)
         self.grompp_args = grompp_args or []
         self.mdrun_args = mdrun_args or []
+        self._counter = itertools.count()
+        self._lock = threading.Lock()
 
-    def state_path(self, path: str | Path) -> Path:
-        path = Path(path)
-        if path.is_absolute():
-            return path
-        scratch_path = self.scratch_dir / path
-        if scratch_path.exists():
-            return scratch_path
-        if path.exists():
-            return path
-        return scratch_path
+    def _uid(self) -> str:
+        with self._lock:
+            n = next(self._counter)
+        return f"{n}_{uuid.uuid4().hex[:8]}"
 
-    def state(self, value: str | Path | GromacsState) -> GromacsState:
-        if isinstance(value, GromacsState):
-            return value
-        gro = self.state_path(value)
-        cpt = gro.with_suffix(".cpt")
-        return GromacsState(gro=gro, cpt=cpt if cpt.exists() else None)
+    def _device_dir(self, device):
+        name = "dev_cpu" if device is None else f"dev{device}"
+        path = self.scratch_dir / name
+        path.mkdir(parents=True, exist_ok=True)
+        return path
 
-    def copy_state(self, src, dst):
-        src_state = self.state(src)
-        dst_path = Path(dst)
-        if dst_path.suffix != ".gro":
-            dst_path = dst_path.with_suffix(".gro")
-        if not dst_path.is_absolute():
-            dst_path = self.scratch_dir / dst_path
-        shutil.copy(src_state.gro, dst_path)
-        dst_cpt = dst_path.with_suffix(".cpt")
-        if src_state.cpt is not None:
-            shutil.copy(src_state.cpt, dst_cpt)
-        elif dst_cpt.exists():
-            dst_cpt.unlink()
-        return GromacsState(dst_path, dst_cpt)
+    def clone_anchor(self, handle):
+        src_gro = Path(handle)
+        src_cpt = src_gro.with_suffix(".cpt")
+        dst_gro = self.scratch_dir / f"anchor_{self._uid()}.gro"
+        dst_gro.write_bytes(src_gro.read_bytes())
+        if src_cpt.exists():
+            dst_gro.with_suffix(".cpt").write_bytes(src_cpt.read_bytes())
+        return str(dst_gro)
 
-    def run_segment(self, input_state, output_prefix):
-        input_state = self.state(input_state)
-        output_name = Path(output_prefix).name
-        is_tau2 = output_name.startswith("tau2_")
-        output_prefix = self.scratch_dir / output_name
-        mdp = self.scratch_dir / f"{output_name}.mdp"
-        tpr = output_prefix.with_suffix(".tpr")
-        out_gro = output_prefix.with_suffix(".gro")
-        out_cpt = output_prefix.with_suffix(".cpt")
+    def run_segment(self, handle, n_steps, *, randomize_velocities, seed, device=None):
+        is_tau2 = not randomize_velocities
+        workdir = self._device_dir(device)
+        stem = f"seg_{self._uid()}"
+        prefix = workdir / stem
+        in_gro = Path(handle)
+        in_cpt = in_gro.with_suffix(".cpt")
+        mdp = workdir / f"{stem}.mdp"
+        tpr = prefix.with_suffix(".tpr")
+        out_gro = prefix.with_suffix(".gro")
+        out_cpt = prefix.with_suffix(".cpt")
 
         write_mdp(
-            mdp,
-            self.tau2_steps if is_tau2 else self.tau1_steps,
-            self.temperature,
-            self.mdp_controls,
-            generate_velocities=not is_tau2,
-            random_seed=RNG.randint(1, 2_000_000_000),
+            mdp, int(n_steps), self.temperature, self.mdp_controls,
+            generate_velocities=randomize_velocities, random_seed=int(seed),
         )
 
-        grompp_cmd = [
-            self.exe,
-            "grompp",
-            "-f",
-            str(mdp),
-            "-c",
-            str(input_state.gro),
-            "-p",
-            self.topology,
-            "-o",
-            str(tpr),
-            "-po",
-            str(output_prefix.with_suffix(".mdout.mdp")),
-            "-maxwarn",
-            str(self.maxwarn),
-            *self.grompp_args,
-        ]
-        if is_tau2 and input_state.cpt is not None:
-            grompp_cmd.extend(["-t", str(input_state.cpt)])
+        env = os.environ.copy()
+        if device is not None:
+            env["CUDA_VISIBLE_DEVICES"] = str(device)
 
-        self._run(grompp_cmd, "grompp")
+        grompp_cmd = [
+            self.exe, "grompp", "-f", str(mdp), "-c", str(in_gro), "-p", self.topology,
+            "-o", str(tpr), "-po", str(prefix.with_suffix(".mdout.mdp")),
+            "-maxwarn", str(self.maxwarn), *self.grompp_args,
+        ]
+        if is_tau2 and in_cpt.exists():
+            grompp_cmd.extend(["-t", str(in_cpt)])
+        self._run(grompp_cmd, "grompp", env)
 
         mdrun_cmd = [
-            self.exe,
-            "mdrun",
-            "-s",
-            str(tpr),
-            "-deffnm",
-            str(output_prefix),
-            "-c",
-            str(out_gro),
-            "-cpo",
-            str(out_cpt),
-            *self.mdrun_args,
+            self.exe, "mdrun", "-s", str(tpr), "-deffnm", str(prefix),
+            "-c", str(out_gro), "-cpo", str(out_cpt), *self.mdrun_args,
         ]
-        self._run(mdrun_cmd, "mdrun")
-        return GromacsState(out_gro, out_cpt)
+        self._run(mdrun_cmd, "mdrun", env)
+        return str(out_gro)
 
-    def load_coords(self, state):
-        return read_gro_coords(self.state(state).gro)
+    def get_coords(self, handle):
+        coords = read_gro_coords(handle)
+        if not np.all(np.isfinite(coords)):
+            raise ValueError(f"GROMACS segment produced non-finite coordinates: {handle}")
+        return coords
 
-    def _run(self, cmd: list[str], stage: str) -> None:
+    def release(self, handle):
+        gro = Path(handle)
+        for sibling in gro.parent.glob(gro.with_suffix("").name + ".*"):
+            try:
+                sibling.unlink()
+            except OSError:
+                pass
+
+    def _run(self, cmd, stage, env):
         try:
-            subprocess.run(cmd, check=True, capture_output=True, text=True)
+            subprocess.run(cmd, check=True, capture_output=True, text=True, env=env)
         except subprocess.CalledProcessError as exc:
             message = [
                 f"GROMACS {stage} failed with exit code {exc.returncode}.",
@@ -277,119 +244,6 @@ class GenericGromacsEngine:
             if exc.stderr:
                 message.append("stderr:\n" + exc.stderr[-4000:])
             raise RuntimeError("\n".join(message)) from exc
-
-
-class GenericPathGennieGromacs:
-    def __init__(
-        self,
-        *,
-        engine,
-        projection_fn,
-        convergence_fn,
-        sigma=0.1,
-        mode="escape",
-        target_projection=None,
-        projection_args=None,
-        convergence_args=None,
-        tau1_workers=1,
-        escape_metric="cv0",
-        reject_worse_tau2=False,
-        reject_worse_anchor=False,
-    ):
-        self.engine = engine
-        self.proj_fn = projection_fn
-        self.conv_fn = convergence_fn
-        self.mode = mode
-        self.sigma = sigma
-        self.target = target_projection
-        self.proj_args = projection_args or {}
-        self.conv_args = convergence_args or {}
-        self.tau1_workers = max(1, int(tau1_workers))
-        self.escape_metric = escape_metric
-        self.reject_worse_tau2 = bool(reject_worse_tau2)
-        self.reject_worse_anchor = bool(reject_worse_anchor)
-
-    def metric(self, cv, start_proj):
-        if self.mode == "escape":
-            if self.escape_metric == "distance_from_start":
-                return np.linalg.norm(cv - start_proj)
-            return float(cv[0])
-        return -np.linalg.norm(cv - self.target)
-
-    def run(self, initial_state, max_trial=20, max_cycle=1000, save_freq=10):
-        anchor_state = self.engine.copy_state(initial_state, "anchor.gro")
-        start_pos = self.engine.load_coords(anchor_state)
-        start_proj = self.proj_fn(start_pos, **self.proj_args)
-        anchor_pos = start_pos
-        anchor_cv = start_proj
-        anchor_metric = self.metric(anchor_cv, start_proj)
-
-        trajectory = []
-        metric_history = []
-
-        def run_trial(cycle, trial):
-            trial_input = self.engine.copy_state(anchor_state, f"trial_{trial}.gro")
-            tau1_state = self.engine.run_segment(trial_input, f"tau1_{cycle}_{trial}")
-            pos = self.engine.load_coords(tau1_state)
-            cv = self.proj_fn(pos, **self.proj_args)
-            return {"state": tau1_state, "metric": self.metric(cv, start_proj), "cv": cv}
-
-        for cycle in trange(max_cycle):
-            previous_anchor_state = anchor_state
-            workers = min(self.tau1_workers, max_trial)
-            if workers == 1:
-                trials = [run_trial(cycle, trial) for trial in range(max_trial)]
-            else:
-                with ThreadPoolExecutor(max_workers=workers) as executor:
-                    trials = list(executor.map(lambda trial: run_trial(cycle, trial), range(max_trial)))
-
-            metrics = np.array([trial["metric"] for trial in trials])
-            mmin = metrics.min()
-            mmax = metrics.max()
-            if abs(mmax - mmin) < 1e-12:
-                probs = np.ones(len(metrics)) / len(metrics)
-            else:
-                scaled = (metrics - mmin) / (mmax - mmin)
-                weights = np.exp((scaled - 1.0) / self.sigma)
-                probs = weights / weights.sum()
-
-            chosen = trials[np.random.choice(len(trials), p=probs)]
-            tau2_state = self.engine.run_segment(chosen["state"], f"tau2_{cycle}")
-            tau2_pos = self.engine.load_coords(tau2_state)
-            tau2_cv = self.proj_fn(tau2_pos, **self.proj_args)
-            tau2_metric = self.metric(tau2_cv, start_proj)
-
-            if self.reject_worse_tau2 and tau2_metric < chosen["metric"]:
-                anchor_state = chosen["state"]
-                pos = self.engine.load_coords(anchor_state)
-                cv = chosen["cv"]
-                metric = chosen["metric"]
-            else:
-                anchor_state = tau2_state
-                pos = tau2_pos
-                cv = tau2_cv
-                metric = tau2_metric
-
-            if self.reject_worse_anchor and metric < anchor_metric:
-                anchor_state = previous_anchor_state
-                pos = anchor_pos
-                cv = anchor_cv
-                metric = anchor_metric
-            else:
-                anchor_pos = pos
-                anchor_cv = cv
-                anchor_metric = metric
-            metric_history.append(metric)
-
-            if cycle % save_freq == 0:
-                print(f"Cycle {cycle}: metric={metric:.4f}, CV={cv}")
-                trajectory.append(pos.copy())
-
-            if self.conv_fn(pos, **self.conv_args):
-                print(f"Converged at cycle {cycle}")
-                break
-
-        return np.asarray(trajectory), np.asarray(metric_history)
 
 
 def run(case_dir: Path, config_name: str = "input.yaml") -> None:
@@ -438,27 +292,6 @@ def run(case_dir: Path, config_name: str = "input.yaml") -> None:
     mdrun_args = [str(arg) for arg in gmx_cfg.get("mdrun_args", [])]
     grompp_args, mdrun_args = split_grompp_only_args(grompp_args, mdrun_args)
 
-    write_mdp(
-        workdir / "tau1.mdp",
-        pg_cfg["tau1_steps"],
-        temperature,
-        mdp_controls,
-        generate_velocities=True,
-        random_seed=-1,
-    )
-    write_mdp(
-        workdir / "tau2.mdp",
-        pg_cfg["tau2_steps"],
-        temperature,
-        mdp_controls,
-        generate_velocities=False,
-        random_seed=-1,
-    )
-    print(
-        f"Using generated GROMACS mdp files: {workdir / 'tau1.mdp'} "
-        f"and {workdir / 'tau2.mdp'}"
-    )
-
     proj_fn = load_function(case_dir, cfg["projection"]["module"], cfg["projection"]["function"])
     conv_fn = load_function(case_dir, cfg["convergence"]["module"], cfg["convergence"]["function"])
 
@@ -475,47 +308,53 @@ def run(case_dir: Path, config_name: str = "input.yaml") -> None:
     projection_args = enrich_args(projection_args, topology_info)
     convergence_args = enrich_args(convergence_args, topology_info)
 
-    initial_cv = proj_fn(read_gro_coords(initial_structure), **projection_args)
-    print(f"Initial CV: {initial_cv}")
+    start_cv = np.asarray(proj_fn(read_gro_coords(initial_structure), **projection_args), dtype=float)
+    print(f"Initial CV: {start_cv}")
 
     mode = pg_cfg.get("mode", "escape")
-    target_projection = None
     if mode == "target":
         if "target_projection" not in pg_cfg:
             raise ValueError("pathgennie.mode is 'target', but pathgennie.target_projection is missing")
-        target_projection = np.asarray(pg_cfg["target_projection"], dtype=float)
-        if target_projection.ndim == 0:
-            target_projection = target_projection.reshape(1)
+        target_projection = np.asarray(pg_cfg["target_projection"], dtype=float).reshape(-1)
+        progress = TargetMetric(proj_fn, target_projection, projection_args=projection_args)
+    else:
+        progress = EscapeMetric(
+            proj_fn, start_cv, projection_args=projection_args,
+            escape_metric=pg_cfg.get("escape_metric", "cv0"),
+        )
 
-    engine = GenericGromacsEngine(
+    def convergence(coords: np.ndarray) -> bool:
+        return bool(conv_fn(coords, **convergence_args))
+
+    engine = CoreGromacsEngine(
         topology=topology,
         executable=executable,
         scratch_dir=scratch_dir,
-        tau1_steps=pg_cfg["tau1_steps"],
-        tau2_steps=pg_cfg["tau2_steps"],
         temperature=temperature,
         mdp_controls=mdp_controls,
         maxwarn=gmx_cfg.get("maxwarn", 1),
         grompp_args=grompp_args,
         mdrun_args=mdrun_args,
     )
-    runner = GenericPathGennieGromacs(
-        engine=engine,
-        projection_fn=proj_fn,
-        convergence_fn=conv_fn,
+
+    devices = pg_cfg.get("devices", gmx_cfg.get("devices"))
+    workers_per_device = int(pg_cfg.get("workers_per_device", pg_cfg.get("tau1_workers", 1)))
+    executor = ThreadDevicePool(devices=devices, workers_per_device=workers_per_device)
+
+    driver = PathGennieDriver(
+        engine, progress, convergence,
+        executor=executor,
         sigma=pg_cfg["sigma"],
-        mode=mode,
-        target_projection=target_projection,
-        projection_args=projection_args,
-        convergence_args=convergence_args,
-        tau1_workers=pg_cfg.get("tau1_workers", 1),
-        escape_metric=pg_cfg.get("escape_metric", "cv0"),
+        seed=pg_cfg.get("seed"),
         reject_worse_tau2=pg_cfg.get("reject_worse_tau2", False),
         reject_worse_anchor=pg_cfg.get("reject_worse_anchor", False),
+        verbosity=pg_cfg.get("verbosity", 1),
     )
 
-    traj, metrics = runner.run(
-        initial_state=str(initial_structure),
+    traj, metrics = driver.run(
+        str(initial_structure),
+        tau1=pg_cfg["tau1_steps"],
+        tau2=pg_cfg["tau2_steps"],
         max_trial=pg_cfg["max_trial"],
         max_cycle=pg_cfg["max_cycle"],
         save_freq=pg_cfg.get("save_freq", 10),

--- a/pathgennie/backends/gromacs/pg_gmx.py
+++ b/pathgennie/backends/gromacs/pg_gmx.py
@@ -27,6 +27,7 @@ import yaml
 from pathgennie.core.driver import PathGennieDriver
 from pathgennie.core.parallel import ThreadDevicePool
 from pathgennie.core.progress import EscapeMetric, TargetMetric
+from pathgennie.core.strategy import resolve_profile
 
 from .utils import (
     enrich_args,
@@ -260,7 +261,7 @@ def run(case_dir: Path, config_name: str = "input.yaml") -> None:
     output_dir.mkdir(parents=True, exist_ok=True)
 
     gmx_cfg = cfg["gromacs"]
-    pg_cfg = cfg["pathgennie"]
+    pg_cfg = resolve_profile(cfg["pathgennie"])
     topology = resolve_case_path(case_dir, gmx_cfg["topology"])
     initial_structure = resolve_case_path(case_dir, gmx_cfg["initial_structure"])
     executable = Path(gmx_cfg["executable"]).expanduser()

--- a/pathgennie/backends/openmm/engine.py
+++ b/pathgennie/backends/openmm/engine.py
@@ -1,0 +1,100 @@
+"""OpenMM in-process engine adapter for the PathGennie core driver.
+
+Wraps a single ``openmm.app.Simulation`` (one Context, one device) behind the
+:class:`pathgennie.core.engine.Engine` protocol so the shared
+:class:`~pathgennie.core.driver.PathGennieDriver` can run the OpenMM backend.
+
+A *handle* is an integer id into a cache of immutable OpenMM ``State`` snapshots.
+Because a ``State`` is immutable, ``clone_anchor`` can hand out a new id that
+shares the same snapshot — ``run_segment`` always ``setState``s, steps, and then
+stores a *new* snapshot, so trials never alias mutable state.  ``setState``/
+``getState`` round-trip positions, velocities **and periodic box vectors**, which
+fixes the box-desync issue in the original loop that only set the box at build
+time.
+
+For multi-GPU in-process execution, construct one ``OpenMMEngine`` per worker
+process (each with a Simulation pinned to its ``CudaDeviceIndex``); OpenMM
+Contexts are not thread-safe, so a process pool — not threads — is required.
+
+Reproducibility note: the driver's selection draws and the per-segment velocity
+randomisation are seeded and reproducible.  A *stochastic* integrator's noise
+stream (e.g. Langevin thermostat) is initialised at context creation and is not
+reliably re-seedable per segment in OpenMM, so bit-identical trajectories are
+only guaranteed with a deterministic integrator (e.g. Verlet).  The best-effort
+``setRandomNumberSeed`` below helps engines/platforms that honour it.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+import numpy as np
+from openmm import State, unit
+from openmm.app import Simulation
+
+from pathgennie.core.progress import ProgressVariable
+
+NM_TO_ANG = 10.0
+
+__all__ = ["OpenMMEngine"]
+
+
+class OpenMMEngine:
+    def __init__(self, simulation: Simulation, temperature: float):
+        self.sim = simulation
+        self.temperature = temperature * unit.kelvin  # type: ignore
+        self._cache: Dict[int, State] = {}
+        self._next_id = 0
+
+    def _store(self, state: State) -> int:
+        handle = self._next_id
+        self._next_id += 1
+        self._cache[handle] = state
+        return handle
+
+    def _snapshot(self) -> State:
+        return self.sim.context.getState(getPositions=True, getVelocities=True)
+
+    def create_state(self, positions, box_vectors=None) -> int:
+        """Initialise the cache from positions (and optional box); return a handle."""
+        self.sim.context.setPositions(positions)
+        if box_vectors is not None:
+            self.sim.context.setPeriodicBoxVectors(*box_vectors)
+        self.sim.context.setVelocitiesToTemperature(self.temperature)
+        return self._store(self._snapshot())
+
+    def clone_anchor(self, handle: int) -> int:
+        # State is immutable; sharing the snapshot is safe.
+        return self._store(self._cache[handle])
+
+    def run_segment(
+        self,
+        handle: int,
+        n_steps: int,
+        *,
+        randomize_velocities: bool,
+        seed: int,
+        device: Optional[int] = None,
+    ) -> int:
+        self.sim.context.setState(self._cache[handle])
+        # Seed the integrator's own RNG (e.g. Langevin thermostat noise) so a
+        # segment is reproducible; setVelocitiesToTemperature's seed only covers
+        # the initial velocity draw, not the noise injected during stepping.
+        try:
+            self.sim.integrator.setRandomNumberSeed(int(seed))
+        except AttributeError:  # integrator without an RNG (e.g. Verlet)
+            pass
+        if randomize_velocities:
+            self.sim.context.setVelocitiesToTemperature(self.temperature, int(seed))
+        self.sim.step(int(n_steps))
+        return self._store(self._snapshot())
+
+    def get_coords(self, handle: int) -> np.ndarray:
+        pos = self._cache[handle].getPositions(asNumpy=True).value_in_unit(unit.nanometer)  # type: ignore
+        coords = np.asarray(pos, dtype=float) * NM_TO_ANG
+        if not np.all(np.isfinite(coords)):
+            raise ValueError("OpenMM segment produced non-finite coordinates (unstable dynamics?)")
+        return coords
+
+    def release(self, handle: int) -> None:
+        self._cache.pop(handle, None)

--- a/pathgennie/backends/openmm/pg_omm.py
+++ b/pathgennie/backends/openmm/pg_omm.py
@@ -1,18 +1,32 @@
+"""OpenMM PathGennie runner.
+
+Thin wrapper that builds an :class:`OpenMMEngine` and the shared
+:class:`~pathgennie.core.driver.PathGennieDriver`.  The adaptive cycle, selection
+and convergence logic now live in :mod:`pathgennie.core`; this class only adapts
+the OpenMM-specific construction and preserves the original public API used by
+``pg_openmm.py``.
+
+PathGennie reference:
+'PathGennie: Rapid Generation of Rare Event Pathways via Direction-Guided
+Adaptive Sampling Using Ultrashort Monitored Trajectories', J. Chem. Theory
+Comput. 2025.
+"""
+
+from __future__ import annotations
+
 from typing import Callable, Dict, Optional
 
-import numpy as np  # type: ignore
-from openmm import unit  # type: ignore
-from openmm.app import Simulation  # type: ignore
-from tqdm.auto import trange
+import numpy as np
+from openmm.app import Simulation
+
+from pathgennie.core.driver import PathGennieDriver
+from pathgennie.core.parallel import SerialExecutor
+from pathgennie.core.progress import EscapeMetric, TargetMetric
+
+from .engine import OpenMMEngine
 
 
 class PathGennieMD:
-    """
-    PathGennie implementation based on:
-    'PathGennie: Rapid Generation of Rare Event Pathways via Direction-Guided Adaptive Sampling Using Ultrashort Monitored Trajectories'
-    J. Chem. Theory Comput. 2016, 12, 5, 2035-2043
-    """
-
     NM_TO_ANG = 10.0
 
     def __init__(
@@ -27,15 +41,14 @@ class PathGennieMD:
         escape_direction: str = "auto",
         temperature: float = 300.0,
         sigma: float = 0.5,
+        seed: Optional[int] = None,
     ):
         if mode not in ("escape", "target"):
-            raise ValueError("mode must be 'escape', 'target'")
+            raise ValueError("mode must be 'escape' or 'target'")
         if mode == "target" and target_projection is None:
             raise ValueError("target_projection required for target mode")
-        if mode == "target" and convergence_fn is None:
-            raise ValueError("convergence_fn required for target mode")
-        if mode == "escape" and convergence_fn is None:
-            raise ValueError("convergence_fn required for escape mode")
+        if convergence_fn is None:
+            raise ValueError("convergence_fn is required")
 
         self.sim = simulation
         self.mode = mode
@@ -44,15 +57,13 @@ class PathGennieMD:
         self.target = np.asarray(target_projection) if target_projection is not None else None
         self.converge_fn = convergence_fn
         self.converge_args = convergence_args or {}
-        self.escape_direction = escape_direction
-
-        # Temperature for velocity re-randomization
-        self.temperature = temperature * unit.kelvin  # type: ignore
+        self.temperature = temperature
         self.sigma = sigma
+        self.seed = seed
 
     def run(
         self,
-        initial_pos: np.ndarray,
+        initial_pos,
         tau1: int = 200,
         tau2: int = 200,
         max_trial: int = 20,
@@ -60,132 +71,31 @@ class PathGennieMD:
         save_freq: int = 10,
         verbosity: int = 1,
     ):
+        engine = OpenMMEngine(self.sim, self.temperature)
+        initial_handle = engine.create_state(initial_pos)
+        start_cv = np.asarray(self.proj_fn(engine.get_coords(initial_handle), **self.proj_args))
 
-        trajectory = []
-        metrics_history = []
+        if self.mode == "escape":
+            progress = EscapeMetric(
+                self.proj_fn, start_cv, projection_args=self.proj_args,
+                escape_metric="distance_from_start",
+            )
+        else:
+            progress = TargetMetric(self.proj_fn, self.target, projection_args=self.proj_args)
 
-        # ---- initialize system ----
-        self.sim.context.setPositions(initial_pos)
-        self.sim.context.setVelocitiesToTemperature(self.temperature)
+        converge_fn = self.converge_fn
+        converge_args = self.converge_args
 
-        # Initial anchor
-        anchor_state = self.sim.context.getState(getPositions=True, getVelocities=True)
-        pos = self._pos()
-        start_proj = self._proj(pos)
-        current_proj = start_proj
+        def convergence(coords: np.ndarray) -> bool:
+            return bool(converge_fn(coords, **converge_args))
 
-        # Metric definition
-        def metric(cv):
-            if self.mode == "escape":
-                return np.linalg.norm(cv - start_proj)
-            else:
-                # Progress is closeness to target
-                return -np.linalg.norm(cv - self.target)
-
-        current_metric = metric(current_proj)
-        cycle_iter = trange(max_cycle, desc="PathGennie") if verbosity >= 2 else range(max_cycle)
-
-        for cycle in cycle_iter:
-            trial_results = []
-
-            #  Run M trials ----
-            for _ in range(max_trial):
-                # Restore anchor positions but randomize velocities
-                self.sim.context.setState(anchor_state)
-                self.sim.context.setVelocitiesToTemperature(self.temperature)
-
-                # sampler segment
-                self.sim.step(tau1)
-
-                trial_pos = self._pos()
-                trial_proj = self._proj(trial_pos)
-                trial_metric = metric(trial_proj)
-
-                # Store the state and metric
-                # We need to store the FULL state after tau1 to continue it later
-                state_after_tau1 = self.sim.context.getState(getPositions=True, getVelocities=True)
-                trial_results.append(
-                    {"metric": trial_metric, "state": state_after_tau1, "pos": trial_pos, "proj": trial_proj}
-                )
-
-            raw_metrics = np.array([r["metric"] for r in trial_results])
-            m_min = np.min(raw_metrics)
-            m_max = np.max(raw_metrics)
-
-            # Avoid division by zero if all trials are identical
-            if (m_max - m_min) < 1e-9:
-                probs = np.ones(len(trial_results)) / len(trial_results)
-            else:
-                # 1. Scale metrics between 0 and 1
-                # 0 = worst trial of this batch, 1 = best trial
-                scaled_metrics = (raw_metrics - m_min) / (m_max - m_min)
-
-                # 2. Boltzmann Weighting on the scaled interval
-                # Shifted by 1.0 so the max weight is always exp(0) = 1
-                logits = (scaled_metrics - 1.0) / (self.sigma + 1e-12)
-                weights = np.exp(logits)
-                probs = weights / np.sum(weights)
-
-            chosen_idx = np.random.choice(len(trial_results), p=probs)
-            best_trial = trial_results[chosen_idx]
-
-            # ---- runner segment ----
-            self.sim.context.setState(best_trial["state"])
-
-            self.sim.step(tau2)
-
-            # Update anchor
-            anchor_state = self.sim.context.getState(getPositions=True, getVelocities=True)
-            pos = self._pos()
-            current_proj = self._proj(pos)
-            current_metric = metric(current_proj)
-            metrics_history.append(current_metric)
-
-            # ---- SAVE (after tau2) ----
-            if cycle % save_freq == 0:
-                trajectory.append(pos * self.NM_TO_ANG)
-                if verbosity:
-                    print(f"Cycle {cycle}: metric={current_metric:.4f}, CV={current_proj}")
-
-            # ---- CONVERGENCE ----
-            converge_fn = self.converge_fn
-            if converge_fn is None:
-                raise ValueError("convergence_fn is required for run()")
-
-            if self.mode == "escape":
-                if converge_fn(pos * self.NM_TO_ANG, **self.converge_args):
-                    if verbosity:
-                        print(f"\nEscape convergence reached at cycle {cycle}")
-                    break
-            else:  # mode == "target"
-                # For target mode, metric is -norm(cv - target), so norm < tol means metric > -tol
-                if converge_fn(pos * self.NM_TO_ANG, **self.converge_args):
-                    if verbosity:
-                        print(f"\nTarget convergence reached at cycle {cycle}")
-                    break
-
-            if verbosity >= 2 and cycle % 10 == 0 and cycle % save_freq != 0:
-                print(f"Cycle {cycle:4d}: metric={current_metric:.4f} (best of {max_trial})")
-
-        if verbosity:
-            print("Final metric:", current_metric)
-
-        return np.array(trajectory), np.array(metrics_history)
-
-    def _get_step_size_ps(self):
-        """Return integrator step size in picoseconds when available."""
-        try:
-            step_size = self.sim.integrator.getStepSize()
-            return step_size.value_in_unit(unit.picosecond)  # type: ignore
-        except Exception:
-            return 1.0
-
-    def _pos(self):
-        """Returns positions as raw numpy array in nanometers"""
-        p = self.sim.context.getState(getPositions=True).getPositions(asNumpy=True)
-        return p.value_in_unit(unit.nanometer)  # type: ignore
-
-    def _proj(self, pos):
-        """pos is raw numpy array in nm. Returns projection (CV) as numpy array."""
-        pos_ang = pos * self.NM_TO_ANG
-        return np.asarray(self.proj_fn(pos_ang, **self.proj_args))
+        driver = PathGennieDriver(
+            engine, progress, convergence,
+            executor=SerialExecutor(),
+            sigma=self.sigma, seed=self.seed, verbosity=verbosity,
+        )
+        return driver.run(
+            initial_handle,
+            tau1=tau1, tau2=tau2, max_trial=max_trial,
+            max_cycle=max_cycle, save_freq=save_freq,
+        )

--- a/pathgennie/backends/openmm/pg_openmm.py
+++ b/pathgennie/backends/openmm/pg_openmm.py
@@ -23,6 +23,8 @@ from pathgennie.backends.amber.utils import (
     write_trajectory,
 )
 
+from pathgennie.core.strategy import resolve_profile
+
 from .pg_omm import PathGennieMD
 
 
@@ -65,7 +67,7 @@ def run(case_dir: Path, config_name: str = "input.yaml") -> None:
     output_dir.mkdir(parents=True, exist_ok=True)
 
     openmm_cfg = cfg["openmm"]
-    pg_cfg = cfg["pathgennie"]
+    pg_cfg = resolve_profile(cfg["pathgennie"])
     topology = resolve_case_path(case_dir, openmm_cfg["topology"])
     initial_restart = resolve_case_path(case_dir, openmm_cfg["initial_restart"])
 
@@ -120,6 +122,7 @@ def run(case_dir: Path, config_name: str = "input.yaml") -> None:
         convergence_args=convergence_args,
         temperature=temperature,
         sigma=pg_cfg.get("sigma", 0.05),
+        seed=pg_cfg.get("seed"),
     )
     trajectory, metrics = runner.run(
         initial_pos=AmberInpcrdFile(str(initial_restart)).positions,  # type: ignore

--- a/pathgennie/core/__init__.py
+++ b/pathgennie/core/__init__.py
@@ -1,1 +1,24 @@
 """Core PathGennie algorithms and shared abstractions."""
+
+from .driver import PathGennieDriver, TrialResult
+from .engine import Engine, Handle
+from .parallel import ParallelExecutor, SerialExecutor, ThreadDevicePool, resolve_devices
+from .progress import CallableProjection, EscapeMetric, ProgressVariable, TargetMetric
+from .selection import selection_probs, softmax_select
+
+__all__ = [
+    "PathGennieDriver",
+    "TrialResult",
+    "Engine",
+    "Handle",
+    "ParallelExecutor",
+    "SerialExecutor",
+    "ThreadDevicePool",
+    "resolve_devices",
+    "CallableProjection",
+    "EscapeMetric",
+    "ProgressVariable",
+    "TargetMetric",
+    "selection_probs",
+    "softmax_select",
+]

--- a/pathgennie/core/driver.py
+++ b/pathgennie/core/driver.py
@@ -157,6 +157,13 @@ class PathGennieDriver:
             anchor, anchor_coords, anchor_cv, anchor_metric = new_anchor, coords, cv, metric
             metric_history.append(metric)
 
+            # Let adaptive progress variables (e.g. SPIB) buffer the path and
+            # retrain on the fly. Done once per cycle on the committed anchor so
+            # the CV is stable within a cycle's project/metric calls.
+            observe = getattr(self.progress, "observe", None)
+            if observe is not None:
+                observe(coords, cycle)
+
             if cycle % save_freq == 0:
                 trajectory.append(coords.copy())
                 last_saved_cycle = cycle

--- a/pathgennie/core/driver.py
+++ b/pathgennie/core/driver.py
@@ -1,0 +1,178 @@
+"""Backend-independent PathGennie adaptive-sampling driver.
+
+This is the single implementation of the cycle that the OpenMM, AMBER and
+GROMACS backends previously each carried their own copy of:
+
+    for cycle in range(max_cycle):
+        run N samplers (tau1) from the anchor with fresh velocities   # swarm
+        score each by progress in CV space and softmax-select one     # selection
+        extend the chosen sampler for tau2 (runner)                   # commit
+        update the anchor, optionally rejecting a worse candidate
+        check convergence
+
+The swarm is evaluated through a :class:`ParallelExecutor`, so spreading the
+``N`` trials across multiple GPUs is a matter of passing a device pool — the
+selection/anchor logic here is untouched by the degree of parallelism.
+
+Correctness fixes relative to the original backends:
+
+* a single master RNG (``seed``) drives both per-segment seeds and the selection
+  draw, so a run is reproducible;
+* the final, converged frame is always saved (the OpenMM loop could skip it when
+  ``cycle % save_freq != 0``);
+* trial handles are released each cycle so scratch usage stays bounded.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, List, Optional
+
+import numpy as np
+
+from .engine import Engine, Handle
+from .parallel import ParallelExecutor, SerialExecutor
+from .progress import ProgressVariable
+from .selection import softmax_select
+
+__all__ = ["PathGennieDriver", "TrialResult"]
+
+
+@dataclass
+class TrialResult:
+    handle: Handle
+    cv: np.ndarray
+    metric: float
+    coords: np.ndarray
+
+
+class PathGennieDriver:
+    def __init__(
+        self,
+        engine: Engine,
+        progress: ProgressVariable,
+        convergence_fn: Callable[[np.ndarray], bool],
+        *,
+        executor: Optional[ParallelExecutor] = None,
+        sigma: float = 0.1,
+        seed: Optional[int] = None,
+        reject_worse_tau2: bool = False,
+        reject_worse_anchor: bool = False,
+        verbosity: int = 1,
+    ):
+        self.engine = engine
+        self.progress = progress
+        self.convergence_fn = convergence_fn
+        self.executor = executor or SerialExecutor()
+        self.sigma = float(sigma)
+        self.rng = np.random.default_rng(seed)
+        self.reject_worse_tau2 = bool(reject_worse_tau2)
+        self.reject_worse_anchor = bool(reject_worse_anchor)
+        self.verbosity = int(verbosity)
+
+    def _seed(self) -> int:
+        return int(self.rng.integers(1, 2_147_483_647))
+
+    def _evaluate(self, coords: np.ndarray):
+        cv = np.asarray(self.progress.project(coords), dtype=float)
+        return cv, float(self.progress.metric(cv))
+
+    def run(
+        self,
+        initial_handle: Handle,
+        *,
+        tau1: int,
+        tau2: int,
+        max_trial: int,
+        max_cycle: int,
+        save_freq: int = 10,
+    ):
+        """Run the adaptive cycle and return ``(trajectory, metrics)`` arrays.
+
+        ``trajectory`` has shape ``(n_saved, n_atoms, 3)`` in Angstrom;
+        ``metrics`` has shape ``(n_cycles,)``.
+        """
+
+        anchor = initial_handle
+        anchor_coords = self.engine.get_coords(anchor)
+        anchor_cv, anchor_metric = self._evaluate(anchor_coords)
+
+        trajectory: List[np.ndarray] = []
+        metric_history: List[float] = []
+        last_saved_cycle = -1
+
+        def worker(trial_index: int, device: Optional[int]) -> TrialResult:
+            handle = self.engine.clone_anchor(anchor)
+            seg = self.engine.run_segment(
+                handle, tau1, randomize_velocities=True, seed=self._seed(), device=device
+            )
+            coords = self.engine.get_coords(seg)
+            cv, metric = self._evaluate(coords)
+            return TrialResult(handle=seg, cv=cv, metric=metric, coords=coords)
+
+        converged_at: Optional[int] = None
+        for cycle in range(max_cycle):
+            previous_anchor = anchor
+
+            trials = self.executor.map(worker, list(range(max_trial)))
+            metrics = np.array([t.metric for t in trials], dtype=float)
+            chosen_idx = softmax_select(metrics, self.sigma, self.rng)
+            chosen = trials[chosen_idx]
+
+            # ---- runner (tau2) from the chosen sampler ----
+            tau2_handle = self.engine.run_segment(
+                chosen.handle, tau2, randomize_velocities=False,
+                seed=self._seed(), device=self.executor.devices[0],
+            )
+            tau2_coords = self.engine.get_coords(tau2_handle)
+            tau2_cv, tau2_metric = self._evaluate(tau2_coords)
+
+            # ---- candidate selection (optional rejection of a worse runner) ----
+            if self.reject_worse_tau2 and tau2_metric < chosen.metric:
+                cand_handle, cand_coords, cand_cv, cand_metric = (
+                    chosen.handle, chosen.coords, chosen.cv, chosen.metric,
+                )
+                self.engine.release(tau2_handle)
+            else:
+                cand_handle, cand_coords, cand_cv, cand_metric = (
+                    tau2_handle, tau2_coords, tau2_cv, tau2_metric,
+                )
+
+            # ---- optional rejection vs the existing anchor ----
+            if self.reject_worse_anchor and cand_metric < anchor_metric:
+                self.engine.release(cand_handle)
+                new_anchor, coords, cv, metric = (
+                    previous_anchor, anchor_coords, anchor_cv, anchor_metric,
+                )
+            else:
+                new_anchor, coords, cv, metric = cand_handle, cand_coords, cand_cv, cand_metric
+
+            # ---- release everything we are not keeping ----
+            for index, trial in enumerate(trials):
+                if trial.handle is not new_anchor and not (index == chosen_idx and cand_handle is chosen.handle):
+                    self.engine.release(trial.handle)
+            if new_anchor is not previous_anchor and previous_anchor is not initial_handle:
+                self.engine.release(previous_anchor)
+
+            anchor, anchor_coords, anchor_cv, anchor_metric = new_anchor, coords, cv, metric
+            metric_history.append(metric)
+
+            if cycle % save_freq == 0:
+                trajectory.append(coords.copy())
+                last_saved_cycle = cycle
+                if self.verbosity:
+                    print(f"Cycle {cycle}: metric={metric:.4f}, CV={cv}")
+
+            if self.convergence_fn(coords):
+                converged_at = cycle
+                if last_saved_cycle != cycle:  # always keep the converged frame
+                    trajectory.append(coords.copy())
+                if self.verbosity:
+                    print(f"Converged at cycle {cycle}")
+                break
+
+        if self.verbosity:
+            tail = f" (converged at {converged_at})" if converged_at is not None else ""
+            print(f"Final metric: {anchor_metric:.4f}{tail}")
+
+        return np.asarray(trajectory), np.asarray(metric_history)

--- a/pathgennie/core/engine.py
+++ b/pathgennie/core/engine.py
@@ -1,0 +1,66 @@
+"""Backend-independent engine protocol for PathGennie.
+
+The OpenMM, AMBER and GROMACS backends each implement the same adaptive cycle
+but with engine-specific state handling.  This module defines the thin contract
+the shared driver (:mod:`pathgennie.core.driver`) needs from any backend so the
+cycle/selection logic only has to be written once.
+
+A *handle* is an opaque, engine-defined token that names a stored simulation
+state.  For the subprocess backends it is typically a restart-file path
+(``rst7``/``gro``); for the in-process OpenMM worker pool it is an id into a
+per-worker state cache.  The driver never inspects a handle, it only passes it
+back to the engine.
+"""
+
+from __future__ import annotations
+
+from typing import Hashable, Optional, Protocol, runtime_checkable
+
+import numpy as np
+
+Handle = Hashable
+
+__all__ = ["Handle", "Engine"]
+
+
+@runtime_checkable
+class Engine(Protocol):
+    """Minimal MD-engine interface used by :class:`PathGennieDriver`."""
+
+    def clone_anchor(self, handle: Handle) -> Handle:
+        """Return a fresh, independent handle initialised from ``handle``.
+
+        Used to seed each sampler trial from the current anchor without the
+        trials clobbering one another's state/scratch files.
+        """
+        ...
+
+    def run_segment(
+        self,
+        handle: Handle,
+        n_steps: int,
+        *,
+        randomize_velocities: bool,
+        seed: int,
+        device: Optional[int] = None,
+    ) -> Handle:
+        """Propagate ``handle`` for ``n_steps`` and return the resulting handle.
+
+        ``randomize_velocities`` selects samplers (τ1, fresh Maxwell-Boltzmann
+        velocities) vs runners (τ2, continued velocities).  ``seed`` makes the
+        segment reproducible; ``device`` is the GPU index when a device pool is
+        in use (``None`` lets the engine choose).
+        """
+        ...
+
+    def get_coords(self, handle: Handle) -> np.ndarray:
+        """Return positions for ``handle`` as an ``(n_atoms, 3)`` array in Angstrom."""
+        ...
+
+    def release(self, handle: Handle) -> None:
+        """Release any resources (scratch files / cache entry) for ``handle``.
+
+        Implementations must tolerate being called with an already-released or
+        anchor handle (no-op) so the driver can release trials unconditionally.
+        """
+        ...

--- a/pathgennie/core/parallel.py
+++ b/pathgennie/core/parallel.py
@@ -1,0 +1,110 @@
+"""Parallel execution of swarm trials across devices.
+
+The driver evaluates ``N`` independent sampler trials per cycle (and ``K*N`` once
+beam/RRT policies are added).  Historically the AMBER/GROMACS backends ran these
+through a bare ``ThreadPoolExecutor`` with **no device assignment**, so every
+worker contended for GPU 0.  This module replaces that with a small executor
+abstraction that round-robins a *pool of devices* across the trials.
+
+An executor maps a ``worker_fn(item, device)`` over a list of work items, where
+``device`` is the GPU index (or ``None``) the trial should run on.  Keeping the
+device-assignment policy here means the selection/cycle logic in
+:mod:`pathgennie.core.driver` is identical regardless of how many GPUs are
+present, and all three backends share one code path.
+
+Two executors are provided:
+
+* :class:`SerialExecutor` — single device, no threads; the reference path that
+  ``ProcessDevicePool``/``ThreadDevicePool`` must match for a fixed seed.
+* :class:`ThreadDevicePool` — a thread per (device x workers_per_device) slot,
+  suitable for the subprocess backends (AMBER ``pmemd.cuda`` / GROMACS
+  ``gmx mdrun``) where the GIL is released during ``subprocess.run`` and each
+  worker exports ``CUDA_VISIBLE_DEVICES`` for its device.
+
+The in-process OpenMM process pool (one long-lived CUDA Context per GPU) is a
+specialisation built on the same ``ParallelExecutor`` contract; see
+``pathgennie/backends/openmm`` for that wiring.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from typing import Callable, List, Optional, Protocol, Sequence, TypeVar
+
+T = TypeVar("T")
+R = TypeVar("R")
+
+__all__ = ["ParallelExecutor", "SerialExecutor", "ThreadDevicePool", "resolve_devices"]
+
+
+def resolve_devices(devices: Optional[Sequence[int]]) -> List[Optional[int]]:
+    """Normalise a device spec into a list usable for round-robin assignment.
+
+    ``None`` or an empty sequence means "let the engine choose" (single slot,
+    device ``None``).
+    """
+
+    if not devices:
+        return [None]
+    return [int(d) for d in devices]
+
+
+class ParallelExecutor(Protocol):
+    """Map ``worker_fn(item, device)`` over ``items`` preserving input order."""
+
+    devices: List[Optional[int]]
+
+    def map(self, worker_fn: Callable[[T, Optional[int]], R], items: Sequence[T]) -> List[R]:
+        ...
+
+    def shutdown(self) -> None:
+        ...
+
+
+class SerialExecutor:
+    """Run all trials sequentially on a single device (reference implementation)."""
+
+    def __init__(self, device: Optional[int] = None):
+        self.devices: List[Optional[int]] = [device]
+
+    def map(self, worker_fn: Callable[[T, Optional[int]], R], items: Sequence[T]) -> List[R]:
+        device = self.devices[0]
+        return [worker_fn(item, device) for item in items]
+
+    def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+class ThreadDevicePool:
+    """Round-robin trials over ``devices`` using a thread pool.
+
+    Each work item ``i`` is assigned ``devices[i % len(devices)]`` so the swarm
+    is spread evenly across GPUs.  ``workers_per_device`` allows more than one
+    concurrent segment per GPU (useful for small systems that under-fill a GPU).
+    Output order matches input order.
+    """
+
+    def __init__(self, devices: Optional[Sequence[int]] = None, workers_per_device: int = 1):
+        self.devices = resolve_devices(devices)
+        self.workers_per_device = max(1, int(workers_per_device))
+        self._max_workers = len(self.devices) * self.workers_per_device
+
+    def map(self, worker_fn: Callable[[T, Optional[int]], R], items: Sequence[T]) -> List[R]:
+        items = list(items)
+        if not items:
+            return []
+        n_workers = min(self._max_workers, len(items))
+        if n_workers == 1:
+            device = self.devices[0]
+            return [worker_fn(item, device) for item in items]
+
+        def run(indexed_item):
+            index, item = indexed_item
+            device = self.devices[index % len(self.devices)]
+            return worker_fn(item, device)
+
+        with ThreadPoolExecutor(max_workers=n_workers) as pool:
+            return list(pool.map(run, enumerate(items)))
+
+    def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass

--- a/pathgennie/core/progress.py
+++ b/pathgennie/core/progress.py
@@ -1,0 +1,88 @@
+"""Progress variables and metrics for PathGennie.
+
+A :class:`ProgressVariable` couples a CV projection ``project(coords) -> cv`` with
+a scalar ``metric(cv) -> float`` where *higher is better*.  The two built-in
+metrics reproduce the original backends:
+
+* :class:`EscapeMetric` — maximise distance from the start CV (escape a minimum /
+  blind exploration).  ``escape_metric="cv0"`` keeps the legacy behaviour of just
+  maximising the first CV component.
+* :class:`TargetMetric` — minimise distance to a target CV (directed exploration);
+  the metric is the negated Euclidean distance.
+
+These wrap, verbatim, the logic in ``pg_omm.py:78-83`` and
+``pg_amber.py:155-160`` so behaviour is preserved while removing duplication.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional, Protocol
+
+import numpy as np
+
+__all__ = ["ProgressVariable", "EscapeMetric", "TargetMetric", "CallableProjection"]
+
+
+class ProgressVariable(Protocol):
+    """Projection + scalar progress metric used to score swarm trials."""
+
+    def project(self, coords: np.ndarray) -> np.ndarray:
+        """Map ``(n_atoms, 3)`` Angstrom coordinates to a CV vector."""
+        ...
+
+    def metric(self, cv: np.ndarray) -> float:
+        """Score a CV vector; larger means more progress."""
+        ...
+
+
+class CallableProjection:
+    """Adapt a plain ``projection_fn(coords, **kwargs)`` to ``project``."""
+
+    def __init__(self, projection_fn: Callable[..., np.ndarray], projection_args: Optional[dict] = None):
+        self._fn = projection_fn
+        self._args = projection_args or {}
+
+    def project(self, coords: np.ndarray) -> np.ndarray:
+        return np.asarray(self._fn(coords, **self._args), dtype=float)
+
+
+class EscapeMetric(CallableProjection):
+    """Maximise progress away from the starting CV."""
+
+    def __init__(
+        self,
+        projection_fn: Callable[..., np.ndarray],
+        start_cv: np.ndarray,
+        *,
+        projection_args: Optional[dict] = None,
+        escape_metric: str = "distance_from_start",
+    ):
+        super().__init__(projection_fn, projection_args)
+        self.start_cv = np.asarray(start_cv, dtype=float)
+        if escape_metric not in ("distance_from_start", "cv0"):
+            raise ValueError("escape_metric must be 'distance_from_start' or 'cv0'")
+        self.escape_metric = escape_metric
+
+    def metric(self, cv: np.ndarray) -> float:
+        cv = np.asarray(cv, dtype=float)
+        if self.escape_metric == "cv0":
+            return float(cv.ravel()[0])
+        return float(np.linalg.norm(cv - self.start_cv))
+
+
+class TargetMetric(CallableProjection):
+    """Minimise distance to a target CV (returned negated so higher is better)."""
+
+    def __init__(
+        self,
+        projection_fn: Callable[..., np.ndarray],
+        target_cv: np.ndarray,
+        *,
+        projection_args: Optional[dict] = None,
+    ):
+        super().__init__(projection_fn, projection_args)
+        self.target_cv = np.asarray(target_cv, dtype=float)
+
+    def metric(self, cv: np.ndarray) -> float:
+        cv = np.asarray(cv, dtype=float)
+        return float(-np.linalg.norm(cv - self.target_cv))

--- a/pathgennie/core/selection.py
+++ b/pathgennie/core/selection.py
@@ -1,0 +1,67 @@
+"""Selection logic for PathGennie swarms.
+
+The same Boltzmann/softmax selection over per-trial progress metrics was
+previously duplicated across the OpenMM, AMBER and GROMACS backends
+(``pg_omm.py``, ``pg_amber.py``, ``pg_gmx.py``).  It now lives here as the single
+source of truth so the behaviour is identical regardless of backend and can be
+unit tested in isolation.
+
+Given a batch of trial metrics (higher == better progress), the metrics are
+min-max scaled onto ``[0, 1]`` and converted to weights ``exp((scaled - 1)/sigma)``.
+Shifting by ``-1`` keeps the largest argument at ``0`` so ``exp`` never overflows.
+``sigma`` controls exploration: small ``sigma`` approaches ``argmax`` (greedy),
+large ``sigma`` approaches a uniform draw.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+__all__ = ["selection_probs", "softmax_select"]
+
+
+def selection_probs(metrics: np.ndarray, sigma: float) -> np.ndarray:
+    """Return normalized selection probabilities for a batch of trial metrics.
+
+    Parameters
+    ----------
+    metrics:
+        1-D array of progress metrics (higher is better).
+    sigma:
+        Selection temperature; must be > 0.
+
+    Notes
+    -----
+    If every metric is (numerically) identical the result is a uniform
+    distribution, matching the degenerate-batch behaviour of the original
+    backends.
+    """
+
+    metrics = np.asarray(metrics, dtype=float).ravel()
+    if metrics.size == 0:
+        raise ValueError("metrics must be non-empty")
+    if not np.all(np.isfinite(metrics)):
+        raise ValueError("metrics contains non-finite values")
+    if sigma <= 0.0:
+        raise ValueError("sigma must be > 0")
+
+    m_min = float(metrics.min())
+    m_max = float(metrics.max())
+    if (m_max - m_min) < 1e-9:
+        return np.full(metrics.shape, 1.0 / metrics.size)
+
+    scaled = (metrics - m_min) / (m_max - m_min)
+    weights = np.exp((scaled - 1.0) / sigma)
+    return weights / weights.sum()
+
+
+def softmax_select(metrics: np.ndarray, sigma: float, rng: np.random.Generator) -> int:
+    """Draw a single trial index using :func:`selection_probs`.
+
+    ``rng`` is an explicit :class:`numpy.random.Generator` so runs are
+    reproducible from a single master seed (the original code used NumPy's
+    global RNG, which made selection non-reproducible).
+    """
+
+    probs = selection_probs(metrics, sigma)
+    return int(rng.choice(probs.size, p=probs))

--- a/pathgennie/core/strategy.py
+++ b/pathgennie/core/strategy.py
@@ -1,0 +1,163 @@
+"""Goal-driven run profiles for PathGennie.
+
+PathGennie was designed as a *greedy* sampler of **ultrashort** (tens of fs)
+trajectories, optimised for the rapid discovery of candidate transition paths to
+seed later path-sampling.  That regime is deliberately different from what is
+needed when the goal shifts to *quantitative* sampling — free-energy surfaces or
+kinetics — where a data-driven CV (SPIB) and downstream enhanced sampling (WE,
+OPES) typically require **longer** segments and more data.
+
+Rather than hard-code one regime, a :class:`RunProfile` bundles the choices that
+should move together for a given goal: segment lengths (``tau1``/``tau2``),
+selection policy, CV type (geometric vs learned), and which downstream stage the
+run feeds.  Two presets are provided; ``resolve_profile`` overlays a profile's
+defaults *under* whatever the user set explicitly (explicit always wins), so
+existing configs are unchanged and a user can opt in with ``profile: discovery``
+or ``profile: sampling`` in ``input.yaml``.
+
+``check_learned_cv_segment_length`` encodes the caveat that a learned CV usually
+needs trajectories long enough to contain real relaxation, warning when the
+configured segments look too short for that goal.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "RunProfile",
+    "DISCOVERY",
+    "SAMPLING",
+    "PROFILES",
+    "get_profile",
+    "resolve_profile",
+    "check_learned_cv_segment_length",
+]
+
+
+@dataclass(frozen=True)
+class RunProfile:
+    """A coherent set of defaults for a sampling goal.
+
+    Attributes
+    ----------
+    goal:
+        ``"discovery"`` (fast candidate paths) or ``"sampling"`` (quantitative
+        free energy / kinetics).
+    selection:
+        Per-cycle policy: ``greedy`` | ``softmax`` | ``beam`` | ``rrt``.
+    cv:
+        ``geometric`` (hand-crafted projection) or ``learned`` (SPIB on the fly).
+    downstream:
+        Enhanced-sampling stage the run feeds: ``None`` | ``weighted_ensemble``
+        | ``opes``.
+    min_learned_cv_segment_ps:
+        Below this per-cycle MD time, a learned CV is flagged as likely
+        under-resolved.
+    """
+
+    name: str
+    goal: str
+    selection: str = "softmax"
+    cv: str = "geometric"
+    tau1_steps: int = 2
+    tau2_steps: int = 8
+    max_trial: int = 15
+    sigma: float = 0.1
+    downstream: Optional[str] = None
+    min_learned_cv_segment_ps: float = 0.1
+
+
+# Fast candidate-path discovery: the original PathGennie regime (greedy on
+# ultrashort, geometric-CV trajectories).
+DISCOVERY = RunProfile(
+    name="discovery",
+    goal="discovery",
+    selection="softmax",
+    cv="geometric",
+    tau1_steps=2,
+    tau2_steps=8,
+    max_trial=15,
+    sigma=0.1,
+    downstream=None,
+)
+
+# Quantitative sampling: longer segments, learned CV permitted, feeds weighted
+# ensemble by default. Numbers are starting points to be tuned per system.
+SAMPLING = RunProfile(
+    name="sampling",
+    goal="sampling",
+    selection="beam",
+    cv="learned",
+    tau1_steps=50,
+    tau2_steps=100,
+    max_trial=20,
+    sigma=0.2,
+    downstream="weighted_ensemble",
+)
+
+PROFILES = {p.name: p for p in (DISCOVERY, SAMPLING)}
+
+
+def get_profile(name: str) -> RunProfile:
+    try:
+        return PROFILES[str(name).lower()]
+    except KeyError:
+        raise KeyError(f"unknown run profile {name!r}; choose from {sorted(PROFILES)}")
+
+
+def resolve_profile(pg_cfg: dict) -> dict:
+    """Return ``pg_cfg`` with the named profile's defaults applied underneath.
+
+    The profile is taken from ``pg_cfg['profile']`` (or ``['goal']``).  Explicit,
+    non-null values in ``pg_cfg`` override the profile; if no profile is named the
+    config is returned unchanged, preserving current behaviour.
+    """
+
+    name = pg_cfg.get("profile") or pg_cfg.get("goal")
+    if name is None:
+        return dict(pg_cfg)
+    profile = get_profile(name)
+    defaults = {
+        "goal": profile.goal,
+        "selection": profile.selection,
+        "cv": profile.cv,
+        "tau1_steps": profile.tau1_steps,
+        "tau2_steps": profile.tau2_steps,
+        "max_trial": profile.max_trial,
+        "sigma": profile.sigma,
+        "downstream": profile.downstream,
+    }
+    explicit = {k: v for k, v in pg_cfg.items() if v is not None}
+    return {**defaults, **explicit}
+
+
+def check_learned_cv_segment_length(
+    tau1_steps: int,
+    tau2_steps: int,
+    timestep_ps: float,
+    *,
+    min_ps: float = 0.1,
+) -> bool:
+    """Warn (and return False) if segments look too short for a learned CV.
+
+    Returns True when the per-cycle MD time ``(tau1+tau2)*dt`` is at least
+    ``min_ps``.  This is advisory — the run still proceeds — to flag the
+    ultrashort-vs-learned-CV mismatch the discovery regime can introduce.
+    """
+
+    segment_ps = (int(tau1_steps) + int(tau2_steps)) * float(timestep_ps)
+    if segment_ps < float(min_ps):
+        logger.warning(
+            "Learned CV requested but per-cycle MD time is %.4f ps (< %.4f ps). "
+            "Ultrashort segments may not give a learnable CV; consider a longer "
+            "tau1/tau2 or the 'sampling' profile.",
+            segment_ps,
+            min_ps,
+        )
+        return False
+    return True

--- a/pathgennie/core/toy.py
+++ b/pathgennie/core/toy.py
@@ -1,0 +1,89 @@
+"""Toy 2-D Langevin engine on the Wolfe-Quapp potential.
+
+This is a pure-NumPy :class:`~pathgennie.core.engine.Engine` implementation used
+to exercise the *entire* driver (swarm -> selection -> runner -> convergence, and
+later beam/RRT policies) without any MD binary or GPU.  It also reproduces the
+paper's §2.4.1 Wolfe-Quapp benchmark: two minima connected by two saddle points,
+the canonical test for whether a sampler can find competing pathways.
+
+The potential (standard Wolfe-Quapp form)::
+
+    V(x, y) = x^4 + y^4 - 2 x^2 - 4 y^2 + x y + 0.3 x + 0.1 y
+
+is integrated with over-damped Langevin (Brownian) dynamics, so swarm diversity
+comes purely from the per-segment random seed — exactly the "selection bias on
+unbiased trajectories" PathGennie relies on.
+
+A *handle* is an integer id into an in-process state cache, mirroring the design
+of the OpenMM worker pool (state stays put; only ids move), which makes this a
+faithful proxy for testing ``clone_anchor`` / ``release`` semantics.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+import numpy as np
+
+__all__ = ["wolfe_quapp_potential", "wolfe_quapp_gradient", "ToyLangevinEngine"]
+
+
+def wolfe_quapp_potential(x: float, y: float) -> float:
+    return x**4 + y**4 - 2.0 * x**2 - 4.0 * y**2 + x * y + 0.3 * x + 0.1 * y
+
+
+def wolfe_quapp_gradient(pos: np.ndarray) -> np.ndarray:
+    x, y = float(pos[0]), float(pos[1])
+    gx = 4.0 * x**3 - 4.0 * x + y + 0.3
+    gy = 4.0 * y**3 - 8.0 * y + x + 0.1
+    return np.array([gx, gy], dtype=float)
+
+
+class ToyLangevinEngine:
+    """Over-damped Langevin dynamics on the Wolfe-Quapp surface."""
+
+    def __init__(self, *, dt: float = 0.002, kT: float = 1.0, gamma: float = 1.0):
+        self.dt = float(dt)
+        self.kT = float(kT)
+        self.gamma = float(gamma)
+        self._cache: Dict[int, np.ndarray] = {}
+        self._next_id = 0
+
+    # -- handle/state management -------------------------------------------------
+    def _store(self, pos: np.ndarray) -> int:
+        handle = self._next_id
+        self._next_id += 1
+        self._cache[handle] = np.asarray(pos, dtype=float).copy()
+        return handle
+
+    def create_state(self, position) -> int:
+        """Seed the cache with an initial 2-D position; returns its handle."""
+        return self._store(np.asarray(position, dtype=float)[:2])
+
+    def clone_anchor(self, handle: int) -> int:
+        return self._store(self._cache[handle])
+
+    def run_segment(
+        self,
+        handle: int,
+        n_steps: int,
+        *,
+        randomize_velocities: bool = True,
+        seed: int = 0,
+        device: Optional[int] = None,
+    ) -> int:
+        rng = np.random.default_rng(seed)
+        pos = self._cache[handle].copy()
+        diffusion = self.kT / self.gamma
+        noise_scale = np.sqrt(2.0 * diffusion * self.dt)
+        for _ in range(int(n_steps)):
+            force = -wolfe_quapp_gradient(pos)
+            pos = pos + (force / self.gamma) * self.dt + noise_scale * rng.standard_normal(2)
+        return self._store(pos)
+
+    def get_coords(self, handle: int) -> np.ndarray:
+        pos = self._cache[handle]
+        return np.array([[pos[0], pos[1], 0.0]], dtype=float)
+
+    def release(self, handle: int) -> None:
+        self._cache.pop(handle, None)

--- a/pathgennie/cv/__init__.py
+++ b/pathgennie/cv/__init__.py
@@ -1,0 +1,16 @@
+"""Data-driven collective variables for PathGennie.
+
+``features`` (pure NumPy) turns coordinates into invariant feature vectors; the
+optional ``spib`` module (requires PyTorch) learns a low-dimensional CV *and* a
+set of metastable states from accumulated swarm frames, exposed to the driver as
+an adaptive :class:`~pathgennie.core.progress.ProgressVariable`.
+"""
+
+from .features import Featurizer, contact_features, dihedral_features, pairwise_distances
+
+__all__ = [
+    "Featurizer",
+    "pairwise_distances",
+    "contact_features",
+    "dihedral_features",
+]

--- a/pathgennie/cv/features.py
+++ b/pathgennie/cv/features.py
@@ -1,0 +1,119 @@
+"""Coordinate featurization for data-driven CVs (pure NumPy).
+
+SPIB (and any learned CV) needs a fixed-length, roughly translation/rotation
+invariant description of a configuration.  This module provides the common
+choices used in the PathGennie examples — pairwise distances, soft contacts and
+dihedral sin/cos — plus a :class:`Featurizer` that composes them and applies
+online standardization, so the learned model sees well-scaled inputs.
+
+Everything here is NumPy-only so it has no heavy dependency and can run inside
+the MD worker; the learned model (PyTorch) consumes these features.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, List, Optional, Sequence
+
+import numpy as np
+
+__all__ = ["pairwise_distances", "contact_features", "dihedral_features", "Featurizer"]
+
+
+def pairwise_distances(coords: np.ndarray, pairs: Sequence[Sequence[int]]) -> np.ndarray:
+    """Euclidean distances for a list of atom-index pairs."""
+    coords = np.asarray(coords, dtype=float)
+    pairs = np.asarray(pairs, dtype=int)
+    diff = coords[pairs[:, 0]] - coords[pairs[:, 1]]
+    return np.linalg.norm(diff, axis=1)
+
+
+def contact_features(coords: np.ndarray, pairs: Sequence[Sequence[int]], r0: float = 8.0, n: int = 6, m: int = 12) -> np.ndarray:
+    """Smooth rational switching-function contacts (1 when close, 0 when far)."""
+    d = pairwise_distances(coords, pairs)
+    x = d / float(r0)
+    # Standard PLUMED-style switching function (1 - x^n) / (1 - x^m).
+    num = 1.0 - np.power(x, n)
+    den = 1.0 - np.power(x, m)
+    # Avoid 0/0 at x == 1 (limit is n/m).
+    out = np.where(np.abs(den) < 1e-9, n / m, num / den)
+    return out
+
+
+def dihedral_features(coords: np.ndarray, quads: Sequence[Sequence[int]]) -> np.ndarray:
+    """sin/cos of each dihedral (continuous, periodicity-safe)."""
+    coords = np.asarray(coords, dtype=float)
+    feats: List[float] = []
+    for a, b, c, d in quads:
+        p0, p1, p2, p3 = coords[a], coords[b], coords[c], coords[d]
+        b0 = -(p1 - p0)
+        b1 = p2 - p1
+        b2 = p3 - p2
+        b1n = b1 / (np.linalg.norm(b1) + 1e-12)
+        v = b0 - np.dot(b0, b1n) * b1n
+        w = b2 - np.dot(b2, b1n) * b1n
+        x = np.dot(v, w)
+        y = np.dot(np.cross(b1n, v), w)
+        angle = np.arctan2(y, x)
+        feats.extend([np.sin(angle), np.cos(angle)])
+    return np.asarray(feats, dtype=float)
+
+
+class Featurizer:
+    """Compose feature functions and apply (optional) online standardization.
+
+    Parameters
+    ----------
+    funcs:
+        List of callables ``f(coords) -> 1-D np.ndarray``.  If empty, the raw
+        flattened coordinates are used (useful for low-dimensional toy systems).
+    standardize:
+        If True, subtract mean / divide by std using statistics accumulated via
+        :meth:`fit` (Welford-style running moments).
+    """
+
+    def __init__(self, funcs: Optional[Sequence[Callable[[np.ndarray], np.ndarray]]] = None, *, standardize: bool = True):
+        self.funcs = list(funcs or [])
+        self.standardize = standardize
+        self._mean: Optional[np.ndarray] = None
+        self._m2: Optional[np.ndarray] = None
+        self._count = 0
+
+    def raw(self, coords: np.ndarray) -> np.ndarray:
+        coords = np.asarray(coords, dtype=float)
+        if not self.funcs:
+            return coords.ravel()
+        return np.concatenate([np.atleast_1d(np.asarray(f(coords), dtype=float).ravel()) for f in self.funcs])
+
+    def fit(self, coords_batch: Sequence[np.ndarray]) -> "Featurizer":
+        """Accumulate standardization statistics from a batch of configurations."""
+        for coords in coords_batch:
+            x = self.raw(coords)
+            self._count += 1
+            if self._mean is None:
+                self._mean = np.zeros_like(x)
+                self._m2 = np.zeros_like(x)
+            delta = x - self._mean
+            self._mean += delta / self._count
+            self._m2 += delta * (x - self._mean)
+        return self
+
+    @property
+    def std(self) -> Optional[np.ndarray]:
+        if self._m2 is None or self._count < 2:
+            return None
+        return np.sqrt(self._m2 / (self._count - 1)) + 1e-8
+
+    def transform(self, coords: np.ndarray) -> np.ndarray:
+        x = self.raw(coords)
+        if self.standardize and self._mean is not None and self.std is not None:
+            return (x - self._mean) / self.std
+        return x
+
+    def transform_batch(self, coords_batch: Sequence[np.ndarray]) -> np.ndarray:
+        return np.stack([self.transform(c) for c in coords_batch])
+
+    @property
+    def n_features(self) -> Optional[int]:
+        if self._mean is not None:
+            return int(self._mean.size)
+        return None

--- a/pathgennie/cv/spib.py
+++ b/pathgennie/cv/spib.py
@@ -1,0 +1,275 @@
+"""State Predictive Information Bottleneck (SPIB) data-driven CV.
+
+SPIB (Wang & Tiwary, *Nat. Commun.* 2021) learns a low-dimensional collective
+variable **and** a set of metastable states at the same time, directly from
+trajectory data, with no hand-crafted reaction coordinate.  It is the
+"self-contained, on-the-fly CV" called for in the PathGennie roadmap.
+
+Mechanism (predictive information bottleneck):
+
+* an encoder ``q(z|x)`` maps a featurized configuration to a Gaussian latent
+  ``z`` (the CV is its mean);
+* a classifier ``p(y|z)`` predicts, from ``z_t``, the *future* metastable-state
+  label ``y_{t+dt}``;
+* training minimises ``CE(p(y|z_t), y_{t+dt}) + beta * KL(q(z|x)||prior)`` — the
+  IB trade-off between predictiveness and compression;
+* state labels are refined self-consistently: after each training round every
+  frame is relabelled by ``argmax p(y|z)``, empty states are dropped, and the
+  number of metastable states **emerges** from the data.
+
+The learned encoder is exposed to the PathGennie driver through
+:class:`SPIBProgress`, an adaptive :class:`~pathgennie.core.progress.ProgressVariable`
+that bootstraps from a coarse geometric CV, buffers the frames the driver
+visits, retrains periodically, and then steers using the learned latent — the
+"iterative path-learning cycle".
+
+This module requires PyTorch; importing it without torch raises ImportError.
+The rest of :mod:`pathgennie.cv` (featurization) has no such dependency.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional, Sequence
+
+import numpy as np
+
+try:
+    import torch
+    import torch.nn as nn
+    import torch.nn.functional as F
+except ImportError as exc:  # pragma: no cover - exercised only without torch
+    raise ImportError("pathgennie.cv.spib requires PyTorch (`pip install torch`)") from exc
+
+from pathgennie.core.progress import ProgressVariable
+
+__all__ = ["SPIB", "train_spib", "SPIBResult", "kmeans_labels", "SPIBProgress"]
+
+
+# --------------------------------------------------------------------------- #
+# Lightweight k-means for label initialisation (avoids a scikit-learn dep).
+# --------------------------------------------------------------------------- #
+def kmeans_labels(x: np.ndarray, k: int, *, iters: int = 50, seed: int = 0) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    n = x.shape[0]
+    k = min(k, n)
+    centers = x[rng.choice(n, size=k, replace=False)].copy()
+    labels = np.zeros(n, dtype=int)
+    for _ in range(iters):
+        d = np.linalg.norm(x[:, None, :] - centers[None, :, :], axis=2)
+        new_labels = d.argmin(axis=1)
+        if np.array_equal(new_labels, labels):
+            break
+        labels = new_labels
+        for j in range(k):
+            members = x[labels == j]
+            if len(members):
+                centers[j] = members.mean(axis=0)
+    return labels
+
+
+class SPIB(nn.Module):
+    def __init__(self, n_features: int, n_states: int, latent_dim: int = 2, hidden: Sequence[int] = (64, 64)):
+        super().__init__()
+        layers: List[nn.Module] = []
+        prev = n_features
+        for h in hidden:
+            layers += [nn.Linear(prev, h), nn.ReLU()]
+            prev = h
+        self.encoder = nn.Sequential(*layers)
+        self.to_mean = nn.Linear(prev, latent_dim)
+        self.to_logvar = nn.Linear(prev, latent_dim)
+        self.classifier = nn.Sequential(nn.Linear(latent_dim, latent_dim), nn.ReLU(), nn.Linear(latent_dim, n_states))
+        self.latent_dim = latent_dim
+        self.n_states = n_states
+
+    def encode(self, x):
+        h = self.encoder(x)
+        return self.to_mean(h), self.to_logvar(h)
+
+    @staticmethod
+    def reparameterize(mean, logvar):
+        std = torch.exp(0.5 * logvar)
+        return mean + std * torch.randn_like(std)
+
+    def forward(self, x):
+        mean, logvar = self.encode(x)
+        z = self.reparameterize(mean, logvar)
+        return self.classifier(z), mean, logvar
+
+
+@dataclass
+class SPIBResult:
+    model: SPIB
+    labels: np.ndarray
+    n_states: int
+    feature_mean: np.ndarray = field(repr=False)
+    feature_std: np.ndarray = field(repr=False)
+
+
+def _kl_standard_normal(mean, logvar):
+    # KL(N(mean, var) || N(0, I)) per sample.
+    return -0.5 * torch.sum(1 + logvar - mean.pow(2) - logvar.exp(), dim=1)
+
+
+def train_spib(
+    features: np.ndarray,
+    *,
+    dt: int = 1,
+    n_states_init: int = 6,
+    latent_dim: int = 2,
+    beta: float = 1e-3,
+    epochs: int = 60,
+    lr: float = 1e-3,
+    n_refine: int = 6,
+    batch_size: int = 256,
+    seed: int = 0,
+) -> SPIBResult:
+    """Train SPIB on a time-ordered ``(n_frames, n_features)`` array.
+
+    Returns the trained model plus the converged per-frame state labels and the
+    emergent number of states.
+    """
+
+    torch.manual_seed(seed)
+    features = np.asarray(features, dtype=np.float64)
+    n = features.shape[0]
+    if n <= dt + 1:
+        raise ValueError("not enough frames for the requested lag time")
+
+    mean = features.mean(axis=0)
+    std = features.std(axis=0) + 1e-8
+    x_std = (features - mean) / std
+    x_all = torch.tensor(x_std, dtype=torch.float32)
+    x_t = x_all[:-dt]
+    fut_index = np.arange(dt, n)  # future frame index for each (t) sample
+
+    labels = kmeans_labels(x_std, n_states_init, seed=seed)
+    n_states = int(labels.max()) + 1
+
+    model: Optional[SPIB] = None
+    for _ in range(n_refine):
+        model = SPIB(features.shape[1], n_states, latent_dim=latent_dim)
+        opt = torch.optim.Adam(model.parameters(), lr=lr)
+        y_future = torch.tensor(labels[fut_index], dtype=torch.long)
+
+        idx = np.arange(x_t.shape[0])
+        for _epoch in range(epochs):
+            np.random.shuffle(idx)
+            for start in range(0, len(idx), batch_size):
+                batch = idx[start : start + batch_size]
+                xb = x_t[batch]
+                yb = y_future[batch]
+                logits, mu, logvar = model(xb)
+                loss = F.cross_entropy(logits, yb) + beta * _kl_standard_normal(mu, logvar).mean()
+                opt.zero_grad()
+                loss.backward()
+                opt.step()
+
+        # Self-consistent relabelling: each frame -> argmax p(y | mean(z)).
+        model.eval()
+        with torch.no_grad():
+            mu_all, _ = model.encode(x_all)
+            new_labels = model.classifier(mu_all).argmax(dim=1).numpy()
+
+        # Drop empty states and remap to a contiguous range.
+        used = np.unique(new_labels)
+        remap = {old: new for new, old in enumerate(used)}
+        new_labels = np.array([remap[v] for v in new_labels], dtype=int)
+        new_n_states = len(used)
+
+        converged = new_n_states == n_states and np.array_equal(new_labels, labels)
+        labels, n_states = new_labels, new_n_states
+        if converged or n_states <= 1:
+            break
+
+    assert model is not None
+    model.eval()
+    return SPIBResult(model=model, labels=labels, n_states=n_states, feature_mean=mean, feature_std=std)
+
+
+class SPIBProgress(ProgressVariable):
+    """Adaptive progress variable backed by an on-the-fly SPIB model.
+
+    Until enough frames are buffered the object delegates to a coarse
+    ``bootstrap`` progress variable; once trained it steers using the learned
+    latent (escape: maximise distance from the start latent; target: minimise
+    distance to the target latent).  ``observe`` is called by the driver each
+    cycle to grow the frame buffer and trigger periodic retraining.
+    """
+
+    def __init__(
+        self,
+        featurizer,
+        bootstrap: ProgressVariable,
+        *,
+        mode: str = "escape",
+        target_coords: Optional[np.ndarray] = None,
+        refresh_every: int = 50,
+        min_frames: int = 40,
+        dt: int = 1,
+        train_kwargs: Optional[dict] = None,
+    ):
+        if mode not in ("escape", "target"):
+            raise ValueError("mode must be 'escape' or 'target'")
+        if mode == "target" and target_coords is None:
+            raise ValueError("target_coords required for target mode")
+        self.featurizer = featurizer
+        self.bootstrap = bootstrap
+        self.mode = mode
+        self.target_coords = None if target_coords is None else np.asarray(target_coords, dtype=float)
+        self.refresh_every = int(refresh_every)
+        self.min_frames = int(min_frames)
+        self.dt = int(dt)
+        self.train_kwargs = dict(train_kwargs or {})
+        self._buffer: List[np.ndarray] = []
+        self.result: Optional[SPIBResult] = None
+        self._z_start: Optional[np.ndarray] = None
+        self._z_target: Optional[np.ndarray] = None
+        self._last_refresh = -1
+
+    # -- driver hook ---------------------------------------------------------
+    def observe(self, coords: np.ndarray, cycle: int) -> None:
+        self._buffer.append(np.asarray(coords, dtype=float).copy())
+        due = (cycle - self._last_refresh) >= self.refresh_every or self.result is None
+        if due and len(self._buffer) >= self.min_frames:
+            self._refresh()
+            self._last_refresh = cycle
+
+    def _encode(self, coords: np.ndarray) -> np.ndarray:
+        assert self.result is not None
+        x = (self.featurizer.raw(coords) - self.result.feature_mean) / self.result.feature_std
+        with torch.no_grad():
+            mu, _ = self.result.model.encode(torch.tensor(x, dtype=torch.float32).unsqueeze(0))
+        return mu.squeeze(0).numpy()
+
+    def _refresh(self) -> None:
+        features = np.stack([self.featurizer.raw(c) for c in self._buffer])
+        if features.shape[0] <= self.dt + 1:
+            return
+        self.result = train_spib(features, dt=self.dt, **self.train_kwargs)
+        self._z_start = self._encode(self._buffer[0])
+        if self.mode == "target":
+            self._z_target = self._encode(self.target_coords)
+
+    # -- ProgressVariable ----------------------------------------------------
+    def project(self, coords: np.ndarray) -> np.ndarray:
+        if self.result is None:
+            return np.asarray(self.bootstrap.project(coords), dtype=float)
+        return self._encode(coords)
+
+    def metric(self, cv: np.ndarray) -> float:
+        if self.result is None:
+            return float(self.bootstrap.metric(cv))
+        cv = np.asarray(cv, dtype=float)
+        if self.mode == "escape":
+            return float(np.linalg.norm(cv - self._z_start))
+        return float(-np.linalg.norm(cv - self._z_target))
+
+    @property
+    def n_states(self) -> Optional[int]:
+        return None if self.result is None else self.result.n_states
+
+    @property
+    def state_labels(self) -> Optional[np.ndarray]:
+        return None if self.result is None else self.result.labels

--- a/pathgennie/cv/spib.py
+++ b/pathgennie/cv/spib.py
@@ -132,6 +132,7 @@ def train_spib(
     """
 
     torch.manual_seed(seed)
+    rng = np.random.default_rng(seed)
     features = np.asarray(features, dtype=np.float64)
     n = features.shape[0]
     if n <= dt + 1:
@@ -155,7 +156,7 @@ def train_spib(
 
         idx = np.arange(x_t.shape[0])
         for _epoch in range(epochs):
-            np.random.shuffle(idx)
+            rng.shuffle(idx)
             for start in range(0, len(idx), batch_size):
                 batch = idx[start : start + batch_size]
                 xb = x_t[batch]

--- a/pathgennie/sampling/__init__.py
+++ b/pathgennie/sampling/__init__.py
@@ -1,0 +1,14 @@
+"""Enhanced-sampling stages built on top of PathGennie output.
+
+PathGennie generates candidate reactive paths cheaply; turning those into
+free-energy surfaces or rate constants is the job of a downstream
+*enhanced-sampling stage*.  This package defines the consistent contract those
+stages share — :class:`PathEnsemble` (what a PathGennie run hands downstream) and
+:class:`SamplingStage` (how a stage consumes it) — so weighted ensemble (WE) and
+OPES can be added as interchangeable implementations rather than bespoke
+scripts.
+"""
+
+from .base import PathEnsemble, SamplingResult, SamplingStage
+
+__all__ = ["PathEnsemble", "SamplingResult", "SamplingStage"]

--- a/pathgennie/sampling/base.py
+++ b/pathgennie/sampling/base.py
@@ -1,0 +1,66 @@
+"""Shared data + protocol for PathGennie enhanced-sampling stages.
+
+A :class:`PathEnsemble` is the hand-off from a PathGennie run to a downstream
+stage.  It carries the reactive path frames plus the extra information that makes
+the path a good *informed seed*: the CV trajectory, optional per-frame metastable
+state labels (e.g. from SPIB, for binning / defining WE bins or OPES states), and
+optional engine handles so a stage can restart MD from any frame.
+
+A :class:`SamplingStage` consumes a :class:`PathEnsemble` (and an engine) and
+returns a :class:`SamplingResult`.  Concrete stages — weighted ensemble (the
+paper's "path-informed WESS") and OPES for free-energy surfaces — implement this
+single ``run`` method, so they are interchangeable and configured the same way
+(``pathgennie.downstream: weighted_ensemble | opes``).
+
+This module is intentionally implementation-free: it fixes the integration
+contract so the WE and OPES stages can be added consistently later.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, List, Optional, Protocol, runtime_checkable
+
+import numpy as np
+
+__all__ = ["PathEnsemble", "SamplingResult", "SamplingStage"]
+
+
+@dataclass
+class PathEnsemble:
+    """Output of a PathGennie run, usable as seeds for enhanced sampling."""
+
+    frames: np.ndarray                                   # (n_frames, n_atoms, 3) Angstrom
+    metrics: np.ndarray                                  # per-cycle progress metric
+    cv_trajectory: Optional[np.ndarray] = None           # (n_frames, n_cv)
+    state_labels: Optional[np.ndarray] = None            # (n_frames,) metastable-state ids
+    handles: List[Any] = field(default_factory=list)     # engine handles for restartable seeds
+    metadata: dict = field(default_factory=dict)
+
+    @property
+    def n_frames(self) -> int:
+        return int(self.frames.shape[0]) if self.frames.ndim == 3 else 0
+
+
+@dataclass
+class SamplingResult:
+    """Result of an enhanced-sampling stage (free energies / rates / weights)."""
+
+    free_energy: Optional[np.ndarray] = None
+    rate_constants: Optional[dict] = None
+    weights: Optional[np.ndarray] = None
+    metadata: dict = field(default_factory=dict)
+
+
+@runtime_checkable
+class SamplingStage(Protocol):
+    """Consume a PathGennie :class:`PathEnsemble` and produce a result.
+
+    Implementations (planned): ``WeightedEnsembleStage`` (path-informed WE for
+    rate constants) and ``OPESStage`` (free-energy surfaces).  ``engine`` is a
+    :class:`pathgennie.core.engine.Engine` so the stage can launch further MD
+    from the ensemble's seed frames.
+    """
+
+    def run(self, ensemble: PathEnsemble, engine: Any, **kwargs: Any) -> SamplingResult:
+        ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ dependencies = [
 examples = [
   "ParmEd",
 ]
+dev = [
+  "pytest",
+]
 
 [project.scripts]
 pathgennie-amber = "pathgennie.backends.amber.pg_amber:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ examples = [
 dev = [
   "pytest",
 ]
+ml = [
+  "torch",
+]
 
 [project.scripts]
 pathgennie-amber = "pathgennie.backends.amber.pg_amber:main"

--- a/tests/test_amber_engine.py
+++ b/tests/test_amber_engine.py
@@ -1,0 +1,80 @@
+"""Validate the device-aware AMBER engine without a real pmemd binary.
+
+``subprocess.run`` is faked to copy the input restart to the output path (so
+coordinates flow through the driver) and to record the ``CUDA_VISIBLE_DEVICES``
+each segment was launched with.  This lets us assert the two behaviours the
+multi-GPU refactor is responsible for: trials are spread across the configured
+devices, and each device gets an isolated scratch subdirectory.
+"""
+
+import threading
+from pathlib import Path
+
+import numpy as np
+
+import pathgennie.backends.amber.engine as amber_engine
+from pathgennie.backends.amber.engine import CoreAmberEngine
+from pathgennie.backends.amber.utils import default_mdin_controls
+from pathgennie.core.driver import PathGennieDriver
+from pathgennie.core.parallel import ThreadDevicePool
+from pathgennie.core.progress import EscapeMetric
+
+REPO = Path(__file__).resolve().parents[1]
+RST7 = REPO / "examples" / "alanine_dipeptide" / "common" / "ala_dipeptide_equilibrated.rst7"
+
+
+def _install_fake_pmemd(monkeypatch, recorder, lock):
+    def fake_run(cmd, check=True, capture_output=True, text=True, env=None):
+        in_path = cmd[cmd.index("-c") + 1]
+        out_path = cmd[cmd.index("-r") + 1]
+        Path(out_path).write_bytes(Path(in_path).read_bytes())
+        with lock:
+            recorder.append({
+                "device": (env or {}).get("CUDA_VISIBLE_DEVICES"),
+                "out_dir": str(Path(out_path).parent),
+            })
+        return None
+
+    monkeypatch.setattr(amber_engine.subprocess, "run", fake_run)
+
+
+def test_amber_swarm_spreads_across_devices(tmp_path, monkeypatch):
+    recorder = []
+    lock = threading.Lock()
+    _install_fake_pmemd(monkeypatch, recorder, lock)
+
+    engine = CoreAmberEngine(
+        topology=RST7,  # never read by the fake; any existing file works
+        executable=Path("/bin/true"),
+        scratch_dir=tmp_path / "scratch",
+        temperature=300.0,
+        mdin_controls=default_mdin_controls("vacuum"),
+    )
+    progress = EscapeMetric(lambda c: np.array([c[0, 0]]), start_cv=np.array([0.0]), escape_metric="cv0")
+
+    driver = PathGennieDriver(
+        engine, progress, convergence_fn=lambda c: False,
+        executor=ThreadDevicePool(devices=[0, 1, 2, 3], workers_per_device=1),
+        sigma=0.1, seed=1, verbosity=0,
+    )
+    driver.run(str(RST7), tau1=1, tau2=1, max_trial=8, max_cycle=2, save_freq=1)
+
+    sampler_devices = {r["device"] for r in recorder}
+    # All four GPUs should have been used by the samplers (runner uses device 0).
+    assert {"0", "1", "2", "3"}.issubset(sampler_devices)
+    # Each device wrote into its own scratch subdirectory.
+    dev_dirs = {Path(r["out_dir"]).name for r in recorder}
+    assert {"dev0", "dev1", "dev2", "dev3"}.issubset(dev_dirs)
+
+
+def test_amber_single_device_sets_env(tmp_path, monkeypatch):
+    recorder = []
+    _install_fake_pmemd(monkeypatch, recorder, threading.Lock())
+    engine = CoreAmberEngine(
+        topology=RST7, executable=Path("/bin/true"),
+        scratch_dir=tmp_path / "scratch", temperature=300.0,
+        mdin_controls=default_mdin_controls("vacuum"),
+    )
+    h = engine.run_segment(str(RST7), 1, randomize_velocities=True, seed=5, device=2)
+    assert Path(h).exists()
+    assert recorder[-1]["device"] == "2"

--- a/tests/test_cv.py
+++ b/tests/test_cv.py
@@ -1,0 +1,57 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "examples" / "alanine_dipeptide" / "common"))
+
+import phi_psi  # noqa: E402
+
+from pathgennie.core.progress import EscapeMetric, TargetMetric  # noqa: E402
+
+
+def test_dihedral_known_geometry():
+    # Atoms placed so the 0-1-2-3 dihedral is exactly +90 degrees.
+    coords = np.array(
+        [
+            [1.0, 0.0, 0.0],   # p0
+            [0.0, 0.0, 0.0],   # p1
+            [0.0, 0.0, 1.0],   # p2 (axis along z)
+            [0.0, 1.0, 1.0],   # p3
+        ]
+    )
+    angle = phi_psi.dihedral_degrees(coords, (0, 1, 2, 3))
+    assert np.isclose(abs(angle), 90.0, atol=1e-6)
+
+
+def test_phi_psi_cv_shape():
+    rng = np.random.default_rng(0)
+    coords = rng.standard_normal((20, 3))
+    cv = phi_psi.phi_psi_cv(coords)
+    assert cv.shape == (2,)
+
+
+def test_angular_wrap():
+    # 170 and -170 degrees are 20 degrees apart, not 340.
+    delta = phi_psi.angular_delta_degrees([170.0], [-170.0])
+    assert np.isclose(abs(delta[0]), 20.0)
+    assert phi_psi.reached_phi_psi.__doc__ is None or True  # smoke
+
+
+def test_target_metric_is_negated_distance():
+    pv = TargetMetric(lambda c: np.array([c[0, 0], c[0, 1]]), target_cv=np.array([0.0, 0.0]))
+    near = pv.metric(np.array([0.1, 0.1]))
+    far = pv.metric(np.array([5.0, 5.0]))
+    assert near > far
+    assert np.isclose(pv.metric(np.array([3.0, 4.0])), -5.0)
+
+
+def test_escape_metric_distance_from_start():
+    pv = EscapeMetric(lambda c: c, start_cv=np.array([0.0, 0.0]), escape_metric="distance_from_start")
+    assert np.isclose(pv.metric(np.array([3.0, 4.0])), 5.0)
+
+
+def test_escape_metric_cv0():
+    pv = EscapeMetric(lambda c: c, start_cv=np.array([0.0, 0.0]), escape_metric="cv0")
+    assert np.isclose(pv.metric(np.array([7.0, 2.0])), 7.0)

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,0 +1,40 @@
+import numpy as np
+
+from pathgennie.cv.features import (
+    Featurizer,
+    contact_features,
+    dihedral_features,
+    pairwise_distances,
+)
+
+
+def test_pairwise_distances():
+    coords = np.array([[0.0, 0.0, 0.0], [3.0, 4.0, 0.0], [0.0, 0.0, 1.0]])
+    d = pairwise_distances(coords, [[0, 1], [0, 2]])
+    np.testing.assert_allclose(d, [5.0, 1.0])
+
+
+def test_contact_features_monotone():
+    coords = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [20.0, 0.0, 0.0]])
+    c = contact_features(coords, [[0, 1], [0, 2]], r0=8.0)
+    assert c[0] > c[1]  # closer pair has the larger contact value
+    assert 0.0 <= c[1] < 0.2
+
+
+def test_dihedral_features_unit_circle():
+    coords = np.array([[1, 0, 0], [0, 0, 0], [0, 0, 1], [0, 1, 1]], dtype=float)
+    f = dihedral_features(coords, [[0, 1, 2, 3]])
+    assert f.shape == (2,)
+    np.testing.assert_allclose(f[0] ** 2 + f[1] ** 2, 1.0, atol=1e-6)  # sin^2+cos^2
+
+
+def test_featurizer_standardize():
+    rng = np.random.default_rng(0)
+    batch = [rng.standard_normal((4, 3)) for _ in range(200)]
+    feat = Featurizer(funcs=[], standardize=True).fit(batch)
+    assert feat.n_features == 12
+    transformed = feat.transform_batch(batch)
+    assert transformed.shape == (200, 12)
+    # Standardized columns should be ~zero mean, ~unit variance.
+    np.testing.assert_allclose(transformed.mean(axis=0), 0.0, atol=0.1)
+    np.testing.assert_allclose(transformed.std(axis=0), 1.0, atol=0.1)

--- a/tests/test_gromacs_engine.py
+++ b/tests/test_gromacs_engine.py
@@ -1,0 +1,72 @@
+"""Validate the device-aware GROMACS engine without real gmx binaries.
+
+Fakes ``subprocess.run`` for both ``gmx grompp`` (records the input structure
+behind the produced .tpr) and ``gmx mdrun`` (copies that structure to the output
+.gro and records the device).  Asserts the swarm spreads across devices and uses
+isolated per-device scratch directories.
+"""
+
+import threading
+from pathlib import Path
+
+import numpy as np
+
+import pathgennie.backends.gromacs.pg_gmx as pg_gmx
+from pathgennie.backends.gromacs.pg_gmx import CoreGromacsEngine
+from pathgennie.core.driver import PathGennieDriver
+from pathgennie.core.parallel import ThreadDevicePool
+from pathgennie.core.progress import EscapeMetric
+
+REPO = Path(__file__).resolve().parents[1]
+GRO = REPO / "examples" / "alanine_dipeptide" / "gromacs" / "ala_dipeptide_equilibrated.gro"
+
+
+def _install_fake_gmx(monkeypatch, recorder, lock):
+    tpr_inputs: dict[str, str] = {}
+
+    def fake_run(cmd, check=True, capture_output=True, text=True, env=None):
+        stage = cmd[1]
+        if stage == "grompp":
+            in_gro = cmd[cmd.index("-c") + 1]
+            tpr = cmd[cmd.index("-o") + 1]
+            with lock:
+                tpr_inputs[tpr] = in_gro
+            Path(tpr).write_text("fake-tpr")
+        elif stage == "mdrun":
+            tpr = cmd[cmd.index("-s") + 1]
+            out_gro = cmd[cmd.index("-c") + 1]
+            out_cpt = cmd[cmd.index("-cpo") + 1]
+            Path(out_gro).write_bytes(Path(tpr_inputs[tpr]).read_bytes())
+            Path(out_cpt).write_text("fake-cpt")
+            with lock:
+                recorder.append({
+                    "device": (env or {}).get("CUDA_VISIBLE_DEVICES"),
+                    "out_dir": str(Path(out_gro).parent),
+                })
+        return None
+
+    monkeypatch.setattr(pg_gmx.subprocess, "run", fake_run)
+
+
+def test_gromacs_swarm_spreads_across_devices(tmp_path, monkeypatch):
+    recorder = []
+    lock = threading.Lock()
+    _install_fake_gmx(monkeypatch, recorder, lock)
+
+    engine = CoreGromacsEngine(
+        topology=GRO, executable=Path("/bin/true"),
+        scratch_dir=tmp_path / "scratch", temperature=300.0,
+        mdp_controls={"integrator": "md", "dt": 0.002},
+    )
+    progress = EscapeMetric(lambda c: np.array([c[0, 0]]), start_cv=np.array([0.0]), escape_metric="cv0")
+    driver = PathGennieDriver(
+        engine, progress, convergence_fn=lambda c: False,
+        executor=ThreadDevicePool(devices=[0, 1, 2, 3], workers_per_device=1),
+        sigma=0.1, seed=1, verbosity=0,
+    )
+    driver.run(str(GRO), tau1=1, tau2=1, max_trial=8, max_cycle=2, save_freq=1)
+
+    devices = {r["device"] for r in recorder}
+    assert {"0", "1", "2", "3"}.issubset(devices)
+    dev_dirs = {Path(r["out_dir"]).name for r in recorder}
+    assert {"dev0", "dev1", "dev2", "dev3"}.issubset(dev_dirs)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+import numpy as np
+
+from pathgennie.backends.amber.utils import (
+    parse_prmtop,
+    read_rst7_coords,
+    wrap_frames_pbc,
+    write_multimodel_pdb,
+)
+
+REPO = Path(__file__).resolve().parents[1]
+COMMON = REPO / "examples" / "alanine_dipeptide" / "common"
+PRMTOP = COMMON / "ala_dipeptide.prmtop"
+RST7 = COMMON / "ala_dipeptide_equilibrated.rst7"
+
+
+def test_rst7_read_shape():
+    coords = read_rst7_coords(RST7)
+    assert coords.ndim == 2 and coords.shape[1] == 3
+    assert np.all(np.isfinite(coords))
+
+
+def test_prmtop_atom_mass_consistency():
+    info = parse_prmtop(PRMTOP)
+    assert len(info["atom_names"]) == len(info["masses"])
+    coords = read_rst7_coords(RST7)
+    assert coords.shape[0] == len(info["atom_names"])
+
+
+def test_multimodel_pdb_roundtrip(tmp_path):
+    info = parse_prmtop(PRMTOP)
+    n_atoms = len(info["atom_names"])
+    frames = np.zeros((2, n_atoms, 3), dtype=float)
+    frames[1] += 1.0
+    out = tmp_path / "traj.pdb"
+    write_multimodel_pdb(out, info, frames)
+    text = out.read_text()
+    assert text.count("MODEL") == 2
+    assert text.count("ENDMDL") == 2
+    # Coordinates should be parseable back from the fixed-width records.
+    xs = [float(line[30:38]) for line in text.splitlines() if line.startswith(("ATOM", "HETATM"))]
+    assert len(xs) == 2 * n_atoms
+
+
+def test_wrap_frames_pbc_no_box_is_identity():
+    info = {"box_lengths": None}
+    frames = np.random.default_rng(0).standard_normal((1, 5, 3))
+    np.testing.assert_array_equal(wrap_frames_pbc(frames, info), frames)

--- a/tests/test_openmm_engine.py
+++ b/tests/test_openmm_engine.py
@@ -1,0 +1,96 @@
+"""Real OpenMM (CPU platform) validation of the engine adapter + core driver.
+
+Builds a tiny system (a few particles in a harmonic well) so the full in-process
+path runs in well under a second on CPU, with no GPU required.  Skipped if
+OpenMM is not installed.
+"""
+
+import numpy as np
+import pytest
+
+openmm = pytest.importorskip("openmm")
+from openmm import (  # noqa: E402
+    CustomExternalForce,
+    LangevinMiddleIntegrator,
+    Platform,
+    System,
+    VerletIntegrator,
+    unit,
+)
+from openmm.app import Simulation, Topology  # noqa: E402
+
+from pathgennie.backends.openmm.engine import OpenMMEngine  # noqa: E402
+from pathgennie.backends.openmm.pg_omm import PathGennieMD  # noqa: E402
+
+
+def _build_simulation(n_particles=3, integrator="langevin"):
+    system = System()
+    for _ in range(n_particles):
+        system.addParticle(12.0 * unit.amu)
+    # Soft harmonic well centred at the origin so dynamics stay bounded.
+    force = CustomExternalForce("0.5*k*(x*x + y*y + z*z)")
+    force.addGlobalParameter("k", 10.0)
+    for i in range(n_particles):
+        force.addParticle(i, [])
+    system.addForce(force)
+
+    topology = Topology()
+    chain = topology.addChain()
+    residue = topology.addResidue("X", chain)
+    for _ in range(n_particles):
+        topology.addAtom("C", None, residue)
+
+    if integrator == "verlet":
+        integ = VerletIntegrator(0.002 * unit.picoseconds)
+    else:
+        integ = LangevinMiddleIntegrator(
+            300.0 * unit.kelvin, 1.0 / unit.picosecond, 0.002 * unit.picoseconds
+        )
+    sim = Simulation(topology, system, integ, Platform.getPlatformByName("CPU"))
+    return sim, n_particles
+
+
+def _positions(n):
+    return [[0.0, 0.0, 0.0] for _ in range(n)] * unit.nanometer
+
+
+def test_openmm_engine_segment_roundtrip():
+    sim, n = _build_simulation()
+    engine = OpenMMEngine(sim, temperature=300.0)
+    h0 = engine.create_state(_positions(n))
+    coords0 = engine.get_coords(h0)
+    assert coords0.shape == (n, 3)
+
+    h1 = engine.clone_anchor(h0)
+    h2 = engine.run_segment(h1, 5, randomize_velocities=True, seed=1)
+    coords2 = engine.get_coords(h2)
+    assert coords2.shape == (n, 3)
+    assert np.all(np.isfinite(coords2))
+    # Original snapshot is untouched by stepping the clone.
+    np.testing.assert_allclose(engine.get_coords(h0), coords0)
+
+
+def test_openmm_engine_run_reproducible():
+    # Deterministic integrator (Verlet): all remaining randomness (velocity
+    # draws + selection) is driven by the driver's seeded RNG, so the run is
+    # bit-reproducible. NOTE: with a stochastic Langevin integrator the
+    # thermostat noise stream is not per-segment reseedable in OpenMM, so only
+    # the driver-level decisions are reproducible there.
+    def run_once():
+        sim, n = _build_simulation(integrator="verlet")
+        runner = PathGennieMD(
+            simulation=sim,
+            projection_fn=lambda c: np.array([c[0, 0]]),
+            mode="escape",
+            convergence_fn=lambda c, **k: abs(c[0, 0]) > 50.0,  # never converges here
+            temperature=300.0,
+            sigma=0.1,
+            seed=2024,
+        )
+        return runner.run(_positions(n), tau1=3, tau2=5, max_trial=6, max_cycle=20, save_freq=2, verbosity=0)
+
+    traj_a, metrics_a = run_once()
+    traj_b, metrics_b = run_once()
+    assert traj_a.shape[0] >= 1
+    np.testing.assert_allclose(metrics_a, metrics_b)
+    np.testing.assert_allclose(traj_a, traj_b)

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -1,0 +1,48 @@
+import numpy as np
+import pytest
+
+from pathgennie.core.selection import selection_probs, softmax_select
+
+
+def test_probs_sum_to_one():
+    probs = selection_probs(np.array([0.1, 0.5, 0.9, 0.3]), sigma=0.2)
+    assert probs.shape == (4,)
+    assert np.isclose(probs.sum(), 1.0)
+    assert np.all(probs >= 0)
+
+
+def test_degenerate_batch_is_uniform():
+    probs = selection_probs(np.array([2.0, 2.0, 2.0]), sigma=0.1)
+    assert np.allclose(probs, 1.0 / 3.0)
+
+
+def test_small_sigma_approaches_argmax():
+    metrics = np.array([0.0, 0.2, 1.0, 0.5])
+    probs = selection_probs(metrics, sigma=1e-3)
+    assert probs.argmax() == metrics.argmax()
+    assert probs[metrics.argmax()] > 0.99
+
+
+def test_large_sigma_approaches_uniform():
+    metrics = np.array([0.0, 0.5, 1.0])
+    probs = selection_probs(metrics, sigma=1e6)
+    assert np.allclose(probs, 1.0 / 3.0, atol=1e-3)
+
+
+def test_softmax_select_is_reproducible():
+    metrics = np.array([0.1, 0.9, 0.4, 0.7])
+    a = softmax_select(metrics, 0.3, np.random.default_rng(123))
+    b = softmax_select(metrics, 0.3, np.random.default_rng(123))
+    assert a == b
+    assert 0 <= a < metrics.size
+
+
+@pytest.mark.parametrize("bad_sigma", [0.0, -1.0])
+def test_invalid_sigma_raises(bad_sigma):
+    with pytest.raises(ValueError):
+        selection_probs(np.array([1.0, 2.0]), sigma=bad_sigma)
+
+
+def test_nonfinite_metrics_raise():
+    with pytest.raises(ValueError):
+        selection_probs(np.array([1.0, np.nan]), sigma=0.1)

--- a/tests/test_smoke_langevin.py
+++ b/tests/test_smoke_langevin.py
@@ -1,0 +1,77 @@
+"""Full-driver smoke + reference tests on the toy Wolfe-Quapp engine.
+
+These exercise the entire adaptive cycle (swarm -> selection -> runner ->
+convergence) with no MD binary or GPU, so they run in CI in well under a second
+while still reproducing the paper's two-minima Wolfe-Quapp behaviour.
+"""
+
+import numpy as np
+
+from pathgennie.core.driver import PathGennieDriver
+from pathgennie.core.parallel import SerialExecutor, ThreadDevicePool
+from pathgennie.core.progress import TargetMetric
+from pathgennie.core.toy import ToyLangevinEngine, wolfe_quapp_gradient
+
+# Wolfe-Quapp minima (numerical stationary points of the potential below).
+SOURCE = (-1.174, 1.477)
+TARGET = np.array([1.124, -1.485])
+
+
+def _xy(coords):
+    return np.array([coords[0, 0], coords[0, 1]])
+
+
+def test_minima_are_stationary_points():
+    # Sanity check the potential: gradient should be near zero at the minima.
+    assert np.linalg.norm(wolfe_quapp_gradient(np.array(SOURCE))) < 1.0
+    assert np.linalg.norm(wolfe_quapp_gradient(TARGET)) < 1.0
+
+
+def _make_driver(executor, seed):
+    engine = ToyLangevinEngine(dt=0.005, kT=1.0, gamma=1.0)
+    initial = engine.create_state(SOURCE)
+    progress = TargetMetric(_xy, target_cv=TARGET)
+
+    def converged(coords):
+        return bool(np.linalg.norm(_xy(coords) - TARGET) < 0.5)
+
+    driver = PathGennieDriver(
+        engine, progress, converged,
+        executor=executor, sigma=0.1, seed=seed, verbosity=0,
+    )
+    return driver, initial
+
+
+def test_driver_reaches_target():
+    driver, initial = _make_driver(SerialExecutor(), seed=7)
+    traj, metrics = driver.run(
+        initial, tau1=20, tau2=40, max_trial=16, max_cycle=400, save_freq=5
+    )
+    assert traj.shape[0] >= 1
+    assert traj.shape[1:] == (1, 3)
+    # The last saved frame should be at (or past) the target basin.
+    assert np.linalg.norm(_xy(traj[-1]) - TARGET) < 0.8
+    # Metric (negated distance to target) should improve overall.
+    assert metrics[-1] > metrics[0]
+
+
+def test_serial_equals_threadpool_single_device():
+    """A device pool with one slot must match serial output for a fixed seed."""
+    d1, i1 = _make_driver(SerialExecutor(), seed=42)
+    t1, m1 = d1.run(i1, tau1=15, tau2=30, max_trial=8, max_cycle=120, save_freq=5)
+
+    d2, i2 = _make_driver(ThreadDevicePool(devices=[0]), seed=42)
+    t2, m2 = d2.run(i2, tau1=15, tau2=30, max_trial=8, max_cycle=120, save_freq=5)
+
+    np.testing.assert_allclose(m1, m2)
+    assert t1.shape == t2.shape
+    np.testing.assert_allclose(t1, t2)
+
+
+def test_round_robin_device_assignment():
+    """ThreadDevicePool spreads work items across devices in order."""
+    pool = ThreadDevicePool(devices=[0, 1, 2, 3])
+    seen = pool.map(lambda item, device: (item, device), list(range(8)))
+    # Items preserve order and devices cycle 0,1,2,3,0,1,2,3.
+    assert [s[0] for s in seen] == list(range(8))
+    assert [s[1] for s in seen] == [0, 1, 2, 3, 0, 1, 2, 3]

--- a/tests/test_spib.py
+++ b/tests/test_spib.py
@@ -1,0 +1,87 @@
+"""SPIB data-driven CV tests (skipped if PyTorch is unavailable)."""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("torch")
+
+from pathgennie.core.driver import PathGennieDriver  # noqa: E402
+from pathgennie.core.parallel import SerialExecutor  # noqa: E402
+from pathgennie.core.progress import TargetMetric  # noqa: E402
+from pathgennie.core.toy import ToyLangevinEngine  # noqa: E402
+from pathgennie.cv.features import Featurizer  # noqa: E402
+from pathgennie.cv.spib import SPIBProgress, kmeans_labels, train_spib  # noqa: E402
+
+
+def _two_state_trajectory(n=600, seed=0):
+    rng = np.random.default_rng(seed)
+    states = [0]
+    for _ in range(1, n):
+        states.append(states[-1] if rng.random() < 0.95 else 1 - states[-1])
+    states = np.array(states)
+    centers = np.array([[-3.0, 0.0], [3.0, 0.0]])
+    feats = centers[states] + 0.3 * rng.standard_normal((n, 2))
+    return feats, states
+
+
+def test_kmeans_separates_clusters():
+    feats, gt = _two_state_trajectory()
+    labels = kmeans_labels(feats, k=2, seed=0)
+    acc = max((labels == gt).mean(), (labels == 1 - gt).mean())
+    assert acc > 0.95
+
+
+def test_spib_recovers_two_states():
+    feats, gt = _two_state_trajectory()
+    res = train_spib(
+        feats, dt=1, n_states_init=4, latent_dim=1,
+        beta=1e-3, epochs=40, n_refine=4, seed=0,
+    )
+    # Emergent number of metastable states should be 2 (started from 4).
+    assert 2 <= res.n_states <= 4
+
+    # The learned latent should separate the two ground-truth basins.
+    import torch
+    x = (feats - res.feature_mean) / res.feature_std
+    with torch.no_grad():
+        z = res.model.encode(torch.tensor(x, dtype=torch.float32))[0].numpy().ravel()
+    sep = abs(z[gt == 0].mean() - z[gt == 1].mean())
+    pooled = z.std() + 1e-9
+    assert sep / pooled > 1.5
+
+    acc = max((res.labels == gt).mean(), (res.labels == 1 - gt).mean())
+    assert acc > 0.85
+
+
+def test_spib_progress_drives_and_switches_to_learned_cv():
+    engine = ToyLangevinEngine(dt=0.005)
+    initial = engine.create_state((-1.174, 1.477))
+    target = np.array([[1.124, -1.485, 0.0]])
+
+    def xy(coords):
+        return np.array([coords[0, 0], coords[0, 1]])
+
+    bootstrap = TargetMetric(xy, target_cv=np.array([1.124, -1.485]))
+    progress = SPIBProgress(
+        Featurizer(funcs=[], standardize=False),
+        bootstrap,
+        mode="target",
+        target_coords=target,
+        refresh_every=15,
+        min_frames=30,
+        dt=1,
+        train_kwargs=dict(n_states_init=3, latent_dim=1, epochs=15, n_refine=2, seed=0),
+    )
+
+    driver = PathGennieDriver(
+        engine, progress, convergence_fn=lambda c: False,
+        executor=SerialExecutor(), sigma=0.2, seed=1, verbosity=0,
+    )
+    traj, metrics = driver.run(initial, tau1=10, tau2=20, max_trial=6, max_cycle=50, save_freq=5)
+
+    # SPIB trained on the fly and the CV is now the learned latent.
+    assert progress.result is not None
+    assert progress.n_states is not None and progress.n_states >= 1
+    learned_cv = progress.project(engine.get_coords(initial))
+    assert learned_cv.shape == (1,)  # latent_dim
+    assert traj.shape[0] >= 1

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -1,0 +1,63 @@
+import logging
+
+import numpy as np
+
+from pathgennie.core.strategy import (
+    DISCOVERY,
+    SAMPLING,
+    check_learned_cv_segment_length,
+    get_profile,
+    resolve_profile,
+)
+from pathgennie.sampling import PathEnsemble, SamplingResult, SamplingStage
+
+
+def test_no_profile_passthrough():
+    cfg = {"tau1_steps": 2, "max_trial": 7}
+    assert resolve_profile(cfg) == cfg
+
+
+def test_profile_fills_defaults():
+    resolved = resolve_profile({"profile": "discovery"})
+    assert resolved["tau1_steps"] == DISCOVERY.tau1_steps
+    assert resolved["cv"] == "geometric"
+    assert resolved["downstream"] is None
+
+
+def test_explicit_overrides_profile():
+    resolved = resolve_profile({"profile": "sampling", "tau1_steps": 5})
+    assert resolved["tau1_steps"] == 5            # explicit wins
+    assert resolved["cv"] == SAMPLING.cv           # profile default kept
+    assert resolved["downstream"] == "weighted_ensemble"
+
+
+def test_get_profile_unknown_raises():
+    try:
+        get_profile("nope")
+        assert False, "expected KeyError"
+    except KeyError:
+        pass
+
+
+def test_learned_cv_segment_guard(caplog):
+    # 2+8 steps * 0.002 ps = 0.02 ps < 0.1 ps -> warn, return False.
+    with caplog.at_level(logging.WARNING):
+        ok = check_learned_cv_segment_length(2, 8, 0.002, min_ps=0.1)
+    assert ok is False
+    assert any("Learned CV" in rec.message for rec in caplog.records)
+    # 50+100 steps * 0.002 ps = 0.3 ps -> fine.
+    assert check_learned_cv_segment_length(50, 100, 0.002, min_ps=0.1) is True
+
+
+def test_path_ensemble_and_stage_contract():
+    frames = np.zeros((3, 4, 3))
+    ens = PathEnsemble(frames=frames, metrics=np.arange(3.0))
+    assert ens.n_frames == 3
+
+    class DummyStage:
+        def run(self, ensemble, engine, **kwargs):
+            return SamplingResult(metadata={"n": ensemble.n_frames})
+
+    stage = DummyStage()
+    assert isinstance(stage, SamplingStage)  # structural Protocol check
+    assert stage.run(ens, engine=None).metadata["n"] == 3


### PR DESCRIPTION
Extract the adaptive-sampling cycle that was duplicated across the OpenMM,
AMBER and GROMACS backends into a backend-independent core:

- core/selection.py: single Boltzmann/softmax selection (probs sum to 1,
  degenerate batch -> uniform, sigma->0 argmax) driven by an explicit RNG.
- core/engine.py: Engine protocol (clone_anchor/run_segment/get_coords/release).
- core/progress.py: ProgressVariable protocol + EscapeMetric/TargetMetric.
- core/parallel.py: ParallelExecutor abstraction with SerialExecutor and a
  ThreadDevicePool that round-robins swarm trials across GPUs (the missing
  per-device assignment behind the current single-GPU contention).
- core/driver.py: PathGennieDriver with reproducible seeding, bounded scratch
  (per-cycle handle release), and always saving the converged frame.
- core/toy.py: pure-NumPy Wolfe-Quapp Langevin engine for CI/benchmarking.
- tests/: selection, CV, I/O round-trip, and full-driver smoke tests incl.
  serial == single-device-pool equivalence. 22 tests pass.

https://claude.ai/code/session_01BtxGQ8fFHgZXDdhWWAF9mS