### PR TITLE
PathGennie v0.2.0: shared core, multi-GPU, SPIB, RRT, roadmap, agent, WE & OPES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,8 +85,13 @@ Weighted Ensemble stage. Existing `input.yaml` cases continue to run unchanged.
   generates an `OPES_METAD` input and drives a PLUMED-capable engine) plus a
   dependency-free, CI-verified OPES core (`OPESBias`, `OPESSimulation`) validated
   on the toy Wolfe–Quapp surface.
+- `path_sampling.py` — OpenPathSampling (OPS) bridge: `PathSamplingStage` runs
+  **TPS/TIS** on a PathGennie seed path (an alternative to WE for kinetics), plus
+  dependency-free, CI-verified seed preparation (`CVRangeState`, `label_frames`,
+  `extract_transition_path`, `tis_interfaces`, `prepare_ops_seed`). Needs the
+  `pathsampling` extra (`openpathsampling`) and an OPS engine to run.
 - `make_stage(name, **cfg)` factory keyed on the `downstream` name
-  (`weighted_ensemble`, `opes`).
+  (`weighted_ensemble`, `opes`, `tps`, `tis`).
 - `runner.py` — `run_downstream` glue that builds a `PathEnsemble` and runs the
   configured stage; wired into all three backends behind `pathgennie.downstream`.
 - `driver.run(..., collect_seeds=True)` returns restartable seed handles aligned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,140 @@
+# Changelog
+
+All notable changes to PathGennie are documented here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project aims to
+follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] — 2026-06-15
+
+This release re-architects PathGennie around a single, backend-independent core
+so the adaptive-sampling cycle is implemented **once** instead of three times,
+makes the swarm genuinely **multi-GPU**, and adds three new capability layers on
+top: a data-driven CV (SPIB), goal-driven run profiles, and a path-informed
+Weighted Ensemble stage. Existing `input.yaml` cases continue to run unchanged.
+
+### Added
+
+**Backend-independent core (`pathgennie/core/`).**
+- `engine.py` — `Engine` protocol (`clone_anchor`, `run_segment`, `get_coords`,
+  `release`) that every backend implements. A *handle* is an opaque token (a
+  restart-file path or an in-process state-cache id).
+- `selection.py` — single source of truth for the Boltzmann/softmax selection
+  (`selection_probs`, `softmax_select`); degenerate (all-equal) batches fall back
+  to a uniform draw, and the largest argument is shifted to 0 so `exp` cannot
+  overflow.
+- `progress.py` — `ProgressVariable` protocol plus the built-in `EscapeMetric`
+  (maximise distance from start, or legacy `cv0`) and `TargetMetric` (minimise
+  distance to a target CV).
+- `driver.py` — `PathGennieDriver`, the one adaptive loop (swarm → select →
+  runner → anchor update → convergence), parameterized by an engine, a progress
+  variable, a convergence function, and a parallel executor.
+- `parallel.py` — `ParallelExecutor` abstraction with `SerialExecutor` and
+  `ThreadDevicePool` (round-robins trials across GPUs); `resolve_devices` helper.
+- `toy.py` — pure-NumPy `ToyLangevinEngine` on the Wolfe–Quapp surface, so the
+  *entire* driver runs in CI in seconds without an MD binary or GPU.
+- `strategy.py` — goal-driven `RunProfile` presets (`discovery`, `sampling`),
+  `resolve_profile`, and `check_learned_cv_segment_length`.
+
+**True multi-GPU scalability.**
+- Device-aware `CoreAmberEngine` (`backends/amber/engine.py`) and
+  `CoreGromacsEngine` (`backends/gromacs/pg_gmx.py`): each segment exports
+  `CUDA_VISIBLE_DEVICES` for its assigned GPU and uses an isolated per-device
+  scratch subdirectory with unique file stems.
+- OpenMM backend rewired onto the shared driver via an `OpenMMEngine`
+  (`backends/openmm/engine.py`).
+- New `pathgennie` config keys: `devices` (GPU index list),
+  `workers_per_device`, and `seed`. Legacy `tau1_workers` is still honoured.
+- `benchmarks/scaling.py` — device-pool scaling benchmark.
+
+**Data-driven collective variables (`pathgennie/cv/`).**
+- `features.py` (NumPy) — `pairwise_distances`, `contact_features`,
+  `dihedral_features`, and a `Featurizer` with online standardization.
+- `spib.py` (PyTorch, optional) — State Predictive Information Bottleneck: a
+  learned CV with an *emergent* number of metastable states, exposed as the
+  adaptive `SPIBProgress` progress variable that bootstraps from a coarse CV,
+  buffers the path, retrains periodically, then steers with the learned latent.
+- `PathGennieDriver` gained an optional per-cycle `observe()` hook so adaptive
+  progress variables can retrain on the fly (no-op for static CVs).
+
+**Non-linear path search (`pathgennie/search/`).**
+- `rrt.py` — Rapidly-exploring Random Trees (`RRT`) and bidirectional
+  `rrt_connect` over the swarm, for pathways the greedy metric cannot follow
+  (backtracking, direction changes, orthogonal CVs). Reuses the `Engine`,
+  `ParallelExecutor`, and `softmax_select`.
+- `roadmap.py` — the conformational `Roadmap` graph (edges weighted by
+  `-log(transition fraction)`) with `dijkstra_path` (minimum-free-energy path)
+  and Yen's `k_shortest_paths` (competing parallel pathways) for all-pairs
+  pathway extraction between metastable states.
+- `core/policy.py` — the `ExplorerPolicy` protocol (`GreedyPolicy`) shared by the
+  driver and the RRT searchers.
+
+**Agentic controller (`pathgennie/agent/`).**
+- `RuleBasedController` — adapts swarm size `N` and segment lengths
+  `tau1`/`tau2` from the recent progress rate (escalate on stall, relax on
+  progress), count-based frontier selection (anti-trapping), a CV-refresh
+  schedule, and a plateau-based stop recommendation. Implements a `Controller`
+  surface a future RL/LLM meta-controller can replace.
+
+**Enhanced-sampling stages (`pathgennie/sampling/`).**
+- `base.py` — the downstream contract: `PathEnsemble`, `SamplingResult`,
+  `SamplingStage`, and `build_path_ensemble`.
+- `weighted_ensemble.py` — path-informed `WeightedEnsembleStage` (Huber–Kim
+  split/merge `resample`, `GridBinner`, `Walker`); reuses the `Engine` and
+  device pool, with optional recycling for steady-state rate constants.
+- `opes.py` — `OPESStage` with a **PLUMED interface** (`build_plumed_opes_input`
+  generates an `OPES_METAD` input and drives a PLUMED-capable engine) plus a
+  dependency-free, CI-verified OPES core (`OPESBias`, `OPESSimulation`) validated
+  on the toy Wolfe–Quapp surface.
+- `make_stage(name, **cfg)` factory keyed on the `downstream` name
+  (`weighted_ensemble`, `opes`).
+- `runner.py` — `run_downstream` glue that builds a `PathEnsemble` and runs the
+  configured stage; wired into all three backends behind `pathgennie.downstream`.
+- `driver.run(..., collect_seeds=True)` returns restartable seed handles aligned
+  with the saved frames, so a run can hand a stage informed seeds.
+- `benchmarks/we_fes.py` — validates the WE free-energy profile against the
+  analytic Wolfe–Quapp marginal.
+
+**Tests & docs.**
+- New `tests/` suite (47 tests): selection, CVs/featurization, I/O round-trips,
+  per-backend device dispatch, SPIB recovery, strategy profiles, full-driver
+  smoke test on the toy engine, and the Weighted Ensemble stage.
+- `docs/` manual and tutorials (this release).
+- `pyproject.toml` optional extras: `dev` (pytest) and `ml` (torch).
+
+### Changed
+- The OpenMM/AMBER/GROMACS backends are now thin adapters (an `Engine`
+  implementation + a `run()` config loader) that delegate to the core driver;
+  the duplicated cycle/selection code was removed.
+- Per-segment state handling restores periodic box vectors (OpenMM) and guards
+  against non-finite coordinates (all backends).
+
+### Fixed
+- **Multi-GPU:** swarm trials no longer all contend for GPU 0 (the old
+  `ThreadPoolExecutor` performed no device assignment).
+- **Scratch races:** concurrent trials no longer write colliding filenames into a
+  shared directory.
+- **Reproducibility:** a single master `seed` drives both selection and
+  per-segment seeds (selection previously used NumPy's global RNG).
+- **Converged frame:** the final converged frame is always saved (the OpenMM loop
+  could skip it when `cycle % save_freq != 0`).
+- **Subprocess errors:** AMBER/GROMACS failures surface stdout/stderr with the
+  failing command instead of an opaque traceback.
+
+### Notes / environment caveats
+- All new layers (RRT, roadmap, controller, WE, OPES, downstream wiring) are
+  verified on the toy/synthetic systems in CI. The **real-MD** code paths
+  (multi-GPU AMBER/GROMACS runs, and downstream stages launched from a real
+  backend) cannot be executed in a CPU-only sandbox without `pmemd`/`gmx`, so
+  they are exercised through the shared, tested helpers rather than a live run.
+- **OPES on real MD requires PLUMED.** `OPESStage(mode="plumed")` generates the
+  `OPES_METAD` input and calls `engine.run_plumed(...)`; the MD engines do not
+  yet implement `run_plumed`, so a PLUMED-patched engine must be supplied. The
+  OPES *algorithm* is verified via `OPESStage(mode="toy")` on an analytic
+  potential. See `docs/opes.md`.
+
+## [0.1.0]
+- Initial PathGennie release: direction-guided adaptive sampling with separate
+  OpenMM, AMBER, and GROMACS runners driven by per-case `input.yaml` files.
+
+[0.2.0]: https://github.com/TeamSuman/PathGennie/releases/tag/v0.2.0
+[0.1.0]: https://github.com/TeamSuman/PathGennie/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ for the kinds of paths PathGennie produces.
 pathgennie/
   core/         Backend-independent driver, selection, progress, device pool,
                 Engine protocol, and a toy Wolfe-Quapp Langevin engine
+  cv/           Data-driven CVs: NumPy featurization + on-the-fly SPIB
+                (learned CV + emergent metastable states; needs PyTorch)
   backends/
     amber/      Device-aware AMBER engine + runner
     gromacs/    Device-aware GROMACS engine + runner
@@ -216,6 +218,17 @@ convergence:
     group_b_resname: MOL
     threshold: 10.0
 ```
+
+## Data-Driven CVs (SPIB)
+
+Instead of a hand-crafted progress variable, PathGennie can learn one on the fly
+with **SPIB** (State Predictive Information Bottleneck, `pathgennie.cv.spib`),
+which jointly learns a low-dimensional CV and an emergent set of metastable
+states from the frames the run visits. `SPIBProgress` bootstraps from a coarse
+geometric CV, buffers the path, retrains periodically (the iterative
+path-learning cycle), and then steers using the learned latent. It is an adaptive
+`ProgressVariable`, so it plugs into the same driver as the built-in metrics.
+Requires the `ml` extra (`pip install -e .[ml]`, i.e. PyTorch).
 
 ## Writing a New Case
 

--- a/README.md
+++ b/README.md
@@ -49,18 +49,24 @@ for the kinds of paths PathGennie produces.
 ```text
 pathgennie/
   core/         Backend-independent driver, selection, progress, device pool,
-                Engine protocol, and a toy Wolfe-Quapp Langevin engine
+                Engine + ExplorerPolicy protocols, strategy profiles, toy engine
   cv/           Data-driven CVs: NumPy featurization + on-the-fly SPIB
                 (learned CV + emergent metastable states; needs PyTorch)
+  search/       Non-linear search: RRT / RRT-Connect + conformational roadmap
+                graph (Dijkstra + Yen k-shortest all-pairs pathways)
+  agent/        Rule-based agentic controller (adaptive N / tau1 / tau2)
   sampling/     Enhanced-sampling stages on one contract (PathEnsemble +
-                SamplingStage): path-informed Weighted Ensemble (+ OPES planned)
+                SamplingStage): path-informed Weighted Ensemble and OPES (PLUMED)
   backends/
     amber/      Device-aware AMBER engine + runner
     gromacs/    Device-aware GROMACS engine + runner
     openmm/     OpenMM in-process engine + runner
-tests/          pytest suite (selection, CV, I/O, OpenMM, device dispatch)
+docs/           Manual + tutorials (start at docs/index.md)
+tests/          pytest suite (69 tests; selection, CV, I/O, device dispatch,
+                SPIB, RRT, roadmap, controller, WE, OPES)
 benchmarks/
   scaling.py    Device-pool scaling benchmark
+  we_fes.py     WE free-energy validation vs the analytic Wolfe-Quapp marginal
 examples/
   alanine_dipeptide/
   CLN025/
@@ -71,8 +77,18 @@ assets/
   unbind.webp
   reaction.webp
   movie.webp
+CHANGELOG.md
 environment.yml
 ```
+
+## Documentation
+
+Full manual and tutorials live in [`docs/`](docs/index.md); release notes in
+[`CHANGELOG.md`](CHANGELOG.md). Highlights: [multi-GPU](docs/multi-gpu.md),
+[strategy profiles](docs/strategy-profiles.md), [SPIB CV](docs/data-driven-cv.md),
+[RRT search](docs/non-linear-search.md), [roadmap graph](docs/roadmap-graph.md),
+[agentic controller](docs/agent.md), [Weighted Ensemble](docs/weighted-ensemble.md),
+and [OPES](docs/opes.md).
 
 ## Installation
 
@@ -246,12 +262,30 @@ multi-GPU executor — no bias forces), and resamples (split/merge, weight-conse
 to keep walkers spread across CV bins along the path. It returns a free-energy
 profile along the CV and, with recycling enabled, a steady-state rate constant.
 
-WE and the planned OPES stage implement one `SamplingStage` contract and are
-selected by name via `make_stage("weighted_ensemble", ...)` (or, eventually, the
-`pathgennie.downstream` config key). To hand WE restartable seeds, run the driver
-with `collect_seeds=True` and build the ensemble with `build_path_ensemble(...)`.
+WE and the OPES stage implement one `SamplingStage` contract and are selected by
+name via `make_stage("weighted_ensemble" | "opes", ...)` or the
+`pathgennie.downstream` config key, which the backends honour: set
+`downstream: weighted_ensemble` (plus a `weighted_ensemble:` block) and the run
+discovers a path then runs WE automatically, writing `free_energy.csv` (and
+`rate_constants.json` if recycling). To do it from Python, run the driver with
+`collect_seeds=True` and build the ensemble with `build_path_ensemble(...)`.
 `benchmarks/we_fes.py` validates the recovered free energy against the analytic
 Wolfe–Quapp marginal (Pearson r ≈ 0.99).
+
+**OPES (free-energy surfaces) via PLUMED.** `OPESStage`
+(`pathgennie.sampling.opes`) generates an `OPES_METAD` PLUMED input and drives a
+PLUMED-capable engine; a dependency-free OPES core (verified on the toy
+Wolfe–Quapp marginal) is also provided. See [docs/opes.md](docs/opes.md).
+
+## Non-Linear Search, Roadmap & Agent
+
+Beyond the greedy path, `pathgennie.search.rrt` provides **RRT / RRT-Connect**
+tree search for pathways the monotone metric cannot follow (backtracking,
+direction changes, orthogonal CVs), `pathgennie.search.roadmap` builds a
+conformational graph and extracts the minimum-free-energy and competing pathways
+between metastable states (Dijkstra + Yen), and `pathgennie.agent` provides a
+rule-based controller that adapts the swarm size and segment lengths on the fly.
+See the [docs](docs/index.md) for details and tutorials.
 
 ## Writing a New Case
 

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ pathgennie/
                 Engine protocol, and a toy Wolfe-Quapp Langevin engine
   cv/           Data-driven CVs: NumPy featurization + on-the-fly SPIB
                 (learned CV + emergent metastable states; needs PyTorch)
-  sampling/     Enhanced-sampling stage contract (PathEnsemble + SamplingStage)
-                for downstream weighted ensemble / OPES
+  sampling/     Enhanced-sampling stages on one contract (PathEnsemble +
+                SamplingStage): path-informed Weighted Ensemble (+ OPES planned)
   backends/
     amber/      Device-aware AMBER engine + runner
     gromacs/    Device-aware GROMACS engine + runner
@@ -235,6 +235,23 @@ geometric CV, buffers the path, retrains periodically (the iterative
 path-learning cycle), and then steers using the learned latent. It is an adaptive
 `ProgressVariable`, so it plugs into the same driver as the built-in metrics.
 Requires the `ml` extra (`pip install -e .[ml]`, i.e. PyTorch).
+
+## Enhanced Sampling: Weighted Ensemble
+
+Once a path is discovered, the `sampling` package turns it into quantitative
+results. `WeightedEnsembleStage` (`pathgennie.sampling.weighted_ensemble`) runs
+**path-informed Weighted Ensemble**: it seeds weighted walkers from the discovered
+`PathEnsemble`, propagates them with *unbiased* MD (reusing the same `Engine` and
+multi-GPU executor — no bias forces), and resamples (split/merge, weight-conserving)
+to keep walkers spread across CV bins along the path. It returns a free-energy
+profile along the CV and, with recycling enabled, a steady-state rate constant.
+
+WE and the planned OPES stage implement one `SamplingStage` contract and are
+selected by name via `make_stage("weighted_ensemble", ...)` (or, eventually, the
+`pathgennie.downstream` config key). To hand WE restartable seeds, run the driver
+with `collect_seeds=True` and build the ensemble with `build_path_ensemble(...)`.
+`benchmarks/we_fes.py` validates the recovered free energy against the analytic
+Wolfe–Quapp marginal (Pearson r ≈ 0.99).
 
 ## Writing a New Case
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ pathgennie/
                 Engine protocol, and a toy Wolfe-Quapp Langevin engine
   cv/           Data-driven CVs: NumPy featurization + on-the-fly SPIB
                 (learned CV + emergent metastable states; needs PyTorch)
+  sampling/     Enhanced-sampling stage contract (PathEnsemble + SamplingStage)
+                for downstream weighted ensemble / OPES
   backends/
     amber/      Device-aware AMBER engine + runner
     gromacs/    Device-aware GROMACS engine + runner
@@ -159,6 +161,10 @@ Each case is driven by an `input.yaml` with four main parts:
   swarm across), `workers_per_device` (concurrent segments per GPU; replaces the
   legacy `tau1_workers`), and `seed` (master RNG seed for the selection and
   velocity draws).
+  Goal key: `profile` (`discovery` for fast candidate paths with ultrashort,
+  greedy, geometric-CV trajectories — the original regime; `sampling` for longer
+  trajectories, a learned CV, and a downstream enhanced-sampling stage). Profile
+  values are defaults; any explicit `pathgennie` key overrides them.
 - `projection`: Python module and function that map coordinates to a
   collective-variable vector.
 - `convergence`: Python module and function that decide when the generated path

--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ environment.yml
 ## Documentation
 
 Full manual and tutorials live in [`docs/`](docs/index.md); release notes in
-[`CHANGELOG.md`](CHANGELOG.md). Highlights: [multi-GPU](docs/multi-gpu.md),
+[`CHANGELOG.md`](CHANGELOG.md); the forward-looking strategic plan in
+[`ROADMAP.md`](ROADMAP.md). Highlights: [multi-GPU](docs/multi-gpu.md),
 [strategy profiles](docs/strategy-profiles.md), [SPIB CV](docs/data-driven-cv.md),
 [RRT search](docs/non-linear-search.md), [roadmap graph](docs/roadmap-graph.md),
 [agentic controller](docs/agent.md), [Weighted Ensemble](docs/weighted-ensemble.md),

--- a/README.md
+++ b/README.md
@@ -48,10 +48,15 @@ for the kinds of paths PathGennie produces.
 
 ```text
 pathgennie/
+  core/         Backend-independent driver, selection, progress, device pool,
+                Engine protocol, and a toy Wolfe-Quapp Langevin engine
   backends/
-    amber/      Generic AMBER runner and utilities
-    gromacs/    Generic GROMACS runner and utilities
-    openmm/     OpenMM runner and in-process PathGennie MD engine
+    amber/      Device-aware AMBER engine + runner
+    gromacs/    Device-aware GROMACS engine + runner
+    openmm/     OpenMM in-process engine + runner
+tests/          pytest suite (selection, CV, I/O, OpenMM, device dispatch)
+benchmarks/
+  scaling.py    Device-pool scaling benchmark
 examples/
   alanine_dipeptide/
   CLN025/
@@ -148,6 +153,10 @@ Each case is driven by an `input.yaml` with four main parts:
   settings.
 - `pathgennie`: adaptive sampling settings such as `mode`, `tau1_steps`,
   `tau2_steps`, `max_trial`, `max_cycle`, `sigma`, and `temperature`.
+  Multi-GPU / reproducibility keys: `devices` (list of GPU indices to spread the
+  swarm across), `workers_per_device` (concurrent segments per GPU; replaces the
+  legacy `tau1_workers`), and `seed` (master RNG seed for the selection and
+  velocity draws).
 - `projection`: Python module and function that map coordinates to a
   collective-variable vector.
 - `convergence`: Python module and function that decide when the generated path
@@ -186,7 +195,9 @@ pathgennie:
     tau1_steps: 5
     tau2_steps: 10
     max_trial: 10
-    tau1_workers: 10
+    devices: [0, 1, 2, 3]   # spread the 10 samplers across 4 GPUs
+    workers_per_device: 1
+    seed: 12345             # reproducible selection / velocity draws
     max_cycle: 5000
     save_freq: 2
     sigma: 0.25

--- a/README.md
+++ b/README.md
@@ -278,6 +278,14 @@ Wolfe–Quapp marginal (Pearson r ≈ 0.99).
 PLUMED-capable engine; a dependency-free OPES core (verified on the toy
 Wolfe–Quapp marginal) is also provided. See [docs/opes.md](docs/opes.md).
 
+**Path sampling (TPS/TIS) via OpenPathSampling.** As an alternative to WE for
+kinetics, `PathSamplingStage` (`pathgennie.sampling.path_sampling`) bridges a
+discovered `PathEnsemble` to [OpenPathSampling](https://openpathsampling.org/):
+PathGennie's reactive path seeds TPS/TIS. The seed preparation (state ranges,
+reactive sub-path extraction, TIS interfaces) is dependency-free and tested;
+running TPS/TIS needs the `pathsampling` extra and an OPS engine. See
+[docs/path-sampling.md](docs/path-sampling.md).
+
 ## Non-Linear Search, Roadmap & Agent
 
 Beyond the greedy path, `pathgennie.search.rrt` provides **RRT / RRT-Connect**

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,202 @@
+# PathGennie Future Roadmap
+
+> **Purpose.** A static, forward-looking plan to evolve PathGennie from a working
+> adaptive-sampling toolkit (v0.2.0) into a globally competitive, cutting-edge
+> enhanced-sampling **framework** comparable to PLUMED and WESTPA.
+>
+> **Scope.** This document is strategy and design intent — not a commitment of
+> dates. For *current* implemented-vs-planned status see
+> [`docs/roadmap.md`](docs/roadmap.md). For released changes see
+> [`CHANGELOG.md`](CHANGELOG.md).
+
+## North star & positioning
+
+PathGennie should **not** try to out-PLUMED PLUMED on CV breadth or out-WESTPA
+WESTPA on weighted-ensemble plumbing. Its defensible, differentiated niche is an
+
+> **autonomous, ML-CV-driven, multi-paradigm rare-event pipeline —
+> *discover → quantify → kinetics* — across MD engines, with an agent deciding
+> how to spend GPU time.**
+
+- **PLUMED** is a *bias/CV library* patched into MD engines; it does not
+  orchestrate discovery or kinetics.
+- **WESTPA** is a *weighted-ensemble* framework; it is not a path-discovery or
+  CV-learning tool.
+- **PathGennie** already unifies greedy/RRT discovery, SPIB CV learning, WE, and
+  OPES behind one `Engine`/`ParallelExecutor`. The roadmap below buys *parity*
+  (Tiers 1–2) and doubles down on *the integration that no one else has*
+  (Tiers 3–4).
+
+## Competitive gap snapshot
+
+| Capability | v0.2.0 | PLUMED | WESTPA | Target tier |
+|---|---|---|---|---|
+| Parallelism | single-node threads | MPI/replica | work managers, multi-node | T1 |
+| Persistence / restart | none | COLVAR/STATE | HDF5 + checkpoint | T1 |
+| WE binning | uniform 1-D | — | MAB/Voronoi/custom, haMSM | T2 |
+| Statistical errors | point estimates | reweight + errors | block/bootstrap | T2 |
+| Real biasing | OPES input only | native C++ | — | T2 |
+| Kinetics / MSM | roadmap graph | — | haMSM, w_ipa | T2 |
+| CV library | thin + SPIB | large | — | T3 |
+| Config / validation | plain YAML dict | keyword files | YAML + tooling | T1 |
+| I/O | synchronous per-frame | streamed | HDF5 streaming | T1 |
+| Real-MD CI | none (toy) | extensive | extensive | T1 |
+
+---
+
+## Tier 1 — Production-grade engineering (parity table stakes)
+
+### T1.1 Storage + checkpoint/restart  *(highest priority)*
+- **Goal:** resumable long runs and a queryable results store (WESTPA's biggest
+  lead). Container restarts currently lose all in-memory state.
+- **Design:** an HDF5/Zarr store (`pathgennie/io/store.py`) holding trajectories,
+  per-cycle/per-walker weights, CV trajectory, SPIB state labels, RNG state, and
+  per-segment provenance. Add `checkpoint()`/`restore()` to `PathGennieDriver`,
+  `WeightedEnsembleStage`, and `RRT`.
+- **Deps:** `h5py`/`zarr`. **Acceptance:** kill + resume a toy WE/RRT run and
+  reproduce the un-interrupted result bit-for-bit.
+
+### T1.2 `WorkManager` abstraction (multi-node)
+- **Goal:** scale past one node and beyond threads.
+- **Design:** generalize `core/parallel.py` `ParallelExecutor` into
+  `serial | process | thread | mpi | dask | ray` work managers; add a
+  **process-pool OpenMM** path (one CUDA context per process). Straggler/retry
+  handling and failed-segment quarantine.
+- **Deps:** `mpi4py`/`dask`/`ray` (optional extras). **Acceptance:** WE/discovery
+  run unchanged across managers; `G=1` ≡ serial for a fixed seed; a 2-process
+  toy run matches serial.
+
+### T1.3 Typed config, unified CLI, plugin registry, sandboxing
+- **Goal:** a real framework UX and safety.
+- **Design:** pydantic/attrs config schema + validation (replace raw `cfg[...]`),
+  one CLI (`pathgennie discover|we|opes|analyze|resume`), entry-point plugins for
+  engines/CVs/binners/stages, and **sandboxed loading of user `projection.py`**
+  (currently `exec`'d via `backends/amber/utils.load_function` — a code-exec risk
+  for a shared package).
+- **Acceptance:** invalid configs fail fast with clear messages; a third-party CV
+  plugin loads via entry point.
+
+### T1.4 Async / streaming I/O
+- **Goal:** stop blocking MD on disk.
+- **Design:** background writer thread/process; chunked HDF5 writes replacing the
+  per-frame `MDAnalysis` path in `backends/*/utils.write_trajectory`.
+
+### T1.5 Real-MD CI, benchmarks, packaging, docs site
+- **Goal:** credibility and reproducibility.
+- **Design:** tiny alanine smoke tests on real `pmemd`/`gmx`/OpenMM in CI;
+  regression baselines; benchmark CI (scaling + FES accuracy); conda-forge
+  package; a `mkdocs-material` site built from `docs/`.
+
+---
+
+## Tier 2 — Sampling-method depth (match WESTPA / PLUMED)
+
+### T2.1 Weighted Ensemble maturity
+- Pluggable `Binner` interface: **MAB**, **Voronoi**, k-means, and **SPIB-state
+  bins** (using `SPIBProgress.state_labels`) alongside the current `GridBinner`.
+- **Walker-history tracking → haMSM** analysis; recycling/flux per bin.
+- **Rate-constant error bars** (block bootstrap) + convergence diagnostics; a
+  `w_ipa`-style analysis CLI. **Acceptance:** WE rate on a benchmark matches a
+  published value within error bars.
+
+### T2.2 Real PLUMED engine bridge
+- Implement `engine.run_plumed(plumed_input, ensemble, **cfg)` (via the `plumed`
+  Python module / engine patches) so `OPESStage(mode="plumed")`, MetaD, umbrella
+  sampling, and funnel-metadynamics run end-to-end on real MD — turning today's
+  OPES *interface* into a capability. **Acceptance:** alanine φ/ψ FES via OPES on
+  a PLUMED-patched OpenMM matches a reference surface.
+
+### T2.3 Estimators & analysis module (`pathgennie/analysis/`)
+- MBAR/WHAM (`pymbar`), block averaging, autocorrelation / statistical
+  inefficiency, bootstrap; standardize `SamplingResult` to carry error bars.
+
+### T2.4 MSM / kinetics
+- Build MSMs from swarm/WE data via `deeptime`; MFPT, committors, TPT fluxes.
+- **Fuse with the roadmap graph** (`search/roadmap.py`) so all-pairs pathways
+  carry *rates*, not just `-log(fraction)` weights.
+
+### T2.5 Path sampling stages
+- TPS / TIS / forward-flux as `SamplingStage`s on the same `Engine`; PathGennie's
+  greedy/RRT paths are natural TPS seeds (a unique structural fit).
+
+---
+
+## Tier 3 — CV & ML ecosystem (differentiate)
+
+### T3.1 CV library + bridges
+- RMSD, native contacts / Q, coordination numbers, secondary structure; an
+  MDAnalysis/mdtraj featurizer bridge; a **PLUMED-CV bridge** (reuse PLUMED CVs
+  as PathGennie progress variables).
+
+### T3.2 Learnable CVs beyond SPIB
+- One `LearnedCV` API behind which **DeepTICA, VAMPnets, committor / Deep-TDA,
+  autoencoders** plug in, with an **active-learning loop** (discover → retrain CV
+  → re-bias).
+
+### T3.3 Closed-loop SPIB → OPES
+- Learn the CV during discovery, then bias OPES along the *learned* latent
+  automatically (the `sampling` profile already anticipates this).
+
+---
+
+## Tier 4 — Differentiators (own the niche)
+
+### T4.1 Autonomous orchestration
+- Upgrade `agent/controller.py` from rule-based to an RL / contextual-bandit
+  policy (state = progress / energy fluctuation / CV gradient; action =
+  `(N, τ1, τ2, frontier)`; reward = progress-per-GPU-second), with an optional
+  **LLM meta-controller** that routes goal → method and drafts the config.
+
+### T4.2 One-config integrated pipeline
+- `discover (RRT/greedy) → quantify (WE/OPES) → kinetics (MSM/roadmap)` from a
+  single config, emitting one results object. This integration *is* the product.
+
+### T4.3 All-pairs roadmap kinetics
+- Combine the roadmap graph with MSM rates into a network of states and transition
+  rates with competing pathways — automated egress/entry-route discovery.
+
+### T4.4 GPU-native ensemble engine
+- Keep state on device, batched CV evaluation, CV-on-GPU (OpenMM `CustomCVForce`),
+  zero host round-trips for the OpenMM swarm.
+
+---
+
+## Cross-cutting technical improvements
+- **Reproducibility at scale:** extend the master-seed model to distributed
+  workers; record full provenance (versions, config, git SHA) in the store.
+- **Observability:** structured logging, metrics, and a live TUI/web dashboard
+  (swarm/WE progress, per-bin occupancy, flux).
+- **Robustness/fault tolerance:** restart failed walkers from checkpoints; NaN /
+  blow-up quarantine with auto-recovery (extends the current finite-checks);
+  disk-space guards.
+- **Performance:** vectorized selection/binning, pinned float32 buffers, avoid
+  OpenMM XML state serialization, batched CV evaluation.
+- **API stability:** semantic versioning + a deprecation policy now that v0.2.0
+  fixes the core protocols.
+
+## Priority queue — the first five
+1. **HDF5 storage + checkpoint/restart** (T1.1) — unblocks every long run and all
+   analysis; closes the #1 gap vs WESTPA.
+2. **`WorkManager` abstraction** (T1.2) — multi-node / process-pool scale.
+3. **Adaptive WE binning + haMSM + rate error bars** (T2.1) — makes WE
+   publication-grade.
+4. **Real PLUMED `run_plumed` engine bridge** (T2.2) — unlocks OPES/MetaD/US on
+   real MD.
+5. **Analysis module (MBAR/block/bootstrap) + deeptime MSM** (T2.3, T2.4).
+
+## Proposed release milestones (indicative, not dates)
+| Version | Theme | Headline items |
+|---|---|---|
+| **0.3.0** | Persistence & scale | T1.1 storage/restart, T1.2 work managers, T1.4 async I/O |
+| **0.4.0** | Framework UX | T1.3 typed config + CLI + plugins + sandboxing, T1.5 real-MD CI / docs site |
+| **0.5.0** | WE & FES rigor | T2.1 adaptive WE + errors, T2.3 estimators, T2.2 PLUMED bridge |
+| **0.6.0** | Kinetics & CV ML | T2.4 MSM, T2.5 path sampling, T3.1–T3.2 CV library + learned CVs |
+| **1.0.0** | Autonomous pipeline | T4.1–T4.4 agentic orchestration, integrated pipeline, GPU-native engine |
+
+## Non-goals / risks
+- **Non-goal:** re-implementing PLUMED's CV catalogue or a new MD integrator —
+  bridge to existing tools instead.
+- **Risk:** breadth over depth. Each tier item must ship with tests and at least
+  one validated benchmark before the next is started.
+- **Risk:** real-MD paths can't be validated in CPU-only CI — gate them behind a
+  GPU/MD CI lane and clearly mark unverified paths (as done in `docs/roadmap.md`).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -115,9 +115,14 @@ WESTPA on weighted-ensemble plumbing. Its defensible, differentiated niche is an
 - **Fuse with the roadmap graph** (`search/roadmap.py`) so all-pairs pathways
   carry *rates*, not just `-log(fraction)` weights.
 
-### T2.5 Path sampling stages
-- TPS / TIS / forward-flux as `SamplingStage`s on the same `Engine`; PathGennie's
-  greedy/RRT paths are natural TPS seeds (a unique structural fit).
+### T2.5 Path sampling stages  *(partially delivered)*
+- **Done:** an OpenPathSampling bridge (`sampling/path_sampling.py`) —
+  `PathSamplingStage` runs TPS/TIS seeded by a PathGennie `PathEnsemble`, with
+  dependency-free, CI-tested seed preparation. Needs the `pathsampling` extra +
+  an OPS engine to run.
+- **Remaining:** forward-flux sampling; turnkey config-driven TPS/TIS from a
+  backend (an OPS engine must currently be supplied via the Python API); kinetics
+  post-analysis helpers (rate error bars, crossing-probability plots).
 
 ---
 

--- a/benchmarks/scaling.py
+++ b/benchmarks/scaling.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+"""Measure how the PathGennie swarm scales across devices.
+
+The multi-GPU win comes from the :class:`~pathgennie.core.parallel.ThreadDevicePool`
+spreading the ``N`` per-cycle sampler segments across GPUs.  Real MD segments
+spend their wall-time inside ``pmemd.cuda`` / ``gmx mdrun`` / an OpenMM kernel,
+i.e. outside the Python GIL, so threads genuinely overlap.
+
+This script reproduces that with a ``SleepEngine`` whose ``run_segment`` sleeps
+for a fixed time (GIL released), modelling a GPU segment of known cost.  It then
+runs the *real* core driver for a fixed number of cycles with 1, 2, 4, ...
+simulated devices and reports cycles/second and speedup, so the dispatch
+overhead of the executor itself can be verified to be small.
+
+To benchmark a real backend instead, point ``--case`` at an ``input.yaml`` and
+set ``pathgennie.devices`` in it; this harness then just times that run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+import threading
+import time
+
+import numpy as np
+
+from pathgennie.core.driver import PathGennieDriver
+from pathgennie.core.parallel import ThreadDevicePool
+from pathgennie.core.progress import EscapeMetric
+
+
+class SleepEngine:
+    """Engine whose segments cost a fixed wall-time (models a GPU MD segment)."""
+
+    def __init__(self, segment_seconds: float = 0.01):
+        self.segment_seconds = float(segment_seconds)
+        self._counter = itertools.count()
+        self._lock = threading.Lock()
+        self._cache: dict[int, np.ndarray] = {}
+
+    def _store(self, pos):
+        with self._lock:
+            h = next(self._counter)
+        self._cache[h] = np.asarray(pos, dtype=float).copy()
+        return h
+
+    def create_state(self, pos):
+        return self._store(pos)
+
+    def clone_anchor(self, handle):
+        return self._store(self._cache[handle])
+
+    def run_segment(self, handle, n_steps, *, randomize_velocities, seed, device=None):
+        time.sleep(self.segment_seconds)  # GIL released, like a real MD call
+        rng = np.random.default_rng(seed)
+        pos = self._cache[handle] + 0.01 * rng.standard_normal(3)
+        return self._store(pos)
+
+    def get_coords(self, handle):
+        return self._cache[handle].reshape(1, 3)
+
+    def release(self, handle):
+        self._cache.pop(handle, None)
+
+
+def benchmark(n_devices_list, *, max_trial, max_cycle, segment_seconds):
+    print(f"max_trial={max_trial}  max_cycle={max_cycle}  segment={segment_seconds*1e3:.1f} ms\n")
+    print(f"{'devices':>8} {'wall (s)':>10} {'cycles/s':>10} {'speedup':>9}")
+    baseline = None
+    for g in n_devices_list:
+        engine = SleepEngine(segment_seconds)
+        initial = engine.create_state(np.zeros(3))
+        progress = EscapeMetric(lambda c: np.array([c[0, 0]]), start_cv=np.array([0.0]), escape_metric="cv0")
+        driver = PathGennieDriver(
+            engine, progress, convergence_fn=lambda c: False,
+            executor=ThreadDevicePool(devices=list(range(g))),
+            sigma=0.1, seed=0, verbosity=0,
+        )
+        t0 = time.perf_counter()
+        driver.run(initial, tau1=1, tau2=1, max_trial=max_trial, max_cycle=max_cycle, save_freq=max_cycle)
+        wall = time.perf_counter() - t0
+        baseline = baseline or wall
+        print(f"{g:>8} {wall:>10.3f} {max_cycle / wall:>10.2f} {baseline / wall:>8.2f}x")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--devices", type=int, nargs="+", default=[1, 2, 4, 8])
+    ap.add_argument("--max-trial", type=int, default=16)
+    ap.add_argument("--max-cycle", type=int, default=20)
+    ap.add_argument("--segment-ms", type=float, default=10.0)
+    args = ap.parse_args()
+    benchmark(args.devices, max_trial=args.max_trial, max_cycle=args.max_cycle,
+              segment_seconds=args.segment_ms / 1000.0)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/we_fes.py
+++ b/benchmarks/we_fes.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+"""Validate the Weighted Ensemble stage against an analytic free energy.
+
+Runs path-informed WE on the toy Wolfe-Quapp engine along the y coordinate and
+compares the recovered free-energy profile F(y) to the analytic marginal
+
+    F(y) = -kT ln integral e^{-V(x,y)/kT} dx
+
+computed numerically.  Prints both profiles (shifted to min 0) and their
+correlation; this is a qualitative physics check, not a CI test.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from pathgennie.core.driver import PathGennieDriver
+from pathgennie.core.parallel import SerialExecutor
+from pathgennie.core.progress import EscapeMetric
+from pathgennie.core.toy import ToyLangevinEngine, wolfe_quapp_potential
+from pathgennie.sampling import WeightedEnsembleStage, build_path_ensemble
+
+
+def analytic_marginal(y_grid, kT):
+    x = np.linspace(-2.5, 2.5, 4001)
+    fe = []
+    for y in y_grid:
+        v = np.array([wolfe_quapp_potential(xi, y) for xi in x])
+        trapz = getattr(np, "trapezoid", getattr(np, "trapz", None))
+        z = trapz(np.exp(-v / kT), x)
+        fe.append(-kT * np.log(z))
+    fe = np.array(fe)
+    return fe - fe.min()
+
+
+def main():
+    kT = 2.0
+    engine = ToyLangevinEngine(dt=0.005, kT=kT)
+    initial = engine.create_state((-1.0, -1.4))
+    progress = EscapeMetric(lambda c: np.array([c[0, 1]]), start_cv=np.array([-1.4]), escape_metric="cv0")
+    driver = PathGennieDriver(
+        engine, progress, convergence_fn=lambda c: False,
+        executor=SerialExecutor(), sigma=0.3, seed=0, verbosity=0,
+    )
+    traj, metrics, handles = driver.run(
+        initial, tau1=5, tau2=10, max_trial=6, max_cycle=60, save_freq=1, collect_seeds=True,
+    )
+    ens = build_path_ensemble(traj, metrics, handles=handles, cv_fn=lambda c: c[0, 1])
+
+    stage = WeightedEnsembleStage(
+        cv_fn=lambda c: c[0, 1], tau_steps=10, n_iterations=400,
+        n_bins=16, target_count=6, seed=1, kT=kT,
+    )
+    result = stage.run(ens, engine)
+
+    centers = result.metadata["bin_centers"]
+    fe_we = result.free_energy
+    finite = np.isfinite(fe_we)
+    fe_an = analytic_marginal(centers, kT)
+
+    print(f"{'y':>8} {'F_WE':>10} {'F_analytic':>12}")
+    for c, a, w, ok in zip(centers, fe_an, fe_we, finite):
+        print(f"{c:>8.3f} {('%.3f' % w) if ok else '   inf':>10} {a:>12.3f}")
+
+    # Correlation over occupied bins (shifted).
+    we = fe_we[finite] - fe_we[finite].min()
+    an = fe_an[finite] - fe_an[finite].min()
+    if we.size > 2:
+        corr = np.corrcoef(we, an)[0, 1]
+        print(f"\nPearson correlation (occupied bins): {corr:.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -1,0 +1,55 @@
+# Agentic controller
+
+The controller automates the "how hard to throw the swarm" decisions that are
+otherwise hand-tuned: the swarm size `N` and segment lengths `tau1`/`tau2`, which
+under-explored frontier to expand, when to refresh a learned CV, and when to stop.
+`RuleBasedController` (`pathgennie/agent/controller.py`) is a deterministic,
+testable policy — the plan's "rule-based first" — implementing a `Controller`
+surface a future RL or LLM meta-controller could replace.
+
+## Behaviour
+
+Given the recent progress history (committed metrics, higher = better):
+
+- **stalling** (progress rate below `stall_eps`) → *escalate*: grow `N` and
+  lengthen `tau1`/`tau2` by `escalate`, clamped to bounds — push harder over the
+  barrier;
+- **progressing** → *relax*: shrink `N` toward its minimum by `relax` — save GPU
+  time (the objective is progress-per-wall-second, not raw progress);
+- **plateaued** for `stop_patience` updates → `should_stop` returns True.
+
+It also offers count-based frontier selection (expand the least-visited region —
+anti-trapping) and a CV-refresh schedule.
+
+## Usage
+
+```python
+from pathgennie.agent import RuleBasedController, SwarmParams
+
+ctrl = RuleBasedController(
+    SwarmParams(n_trial=8, tau1=4, tau2=8),
+    n_bounds=(4, 64), tau1_bounds=(2, 200), tau2_bounds=(4, 400),
+    stall_window=5, stall_eps=1e-3, escalate=1.5, relax=0.75,
+    stop_patience=20, refresh_every=50,
+)
+
+metric_history = []
+for cycle in range(max_cycle):
+    params = ctrl.update(metric_history)        # adapt N, tau1, tau2
+    # ... run one driver cycle with params.n_trial / params.tau1 / params.tau2 ...
+    metric_history.append(latest_metric)
+    if ctrl.should_refresh_cv(cycle):
+        ...                                     # trigger SPIB retraining
+    if ctrl.should_stop(metric_history):
+        break
+```
+
+`RuleBasedController.choose_frontier(visit_counts)` returns the least-visited node
+index, for steering RRT expansion away from over-sampled regions.
+
+## Extending it
+
+`Controller` is a `Protocol` (`update`, `should_stop`). A contextual-bandit/RL
+controller (state = local CV gradient / progress; action = `(N, tau1, tau2)`;
+reward = progress per wall-second) or an LLM meta-controller can implement the
+same surface and drop in without changing the driver.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,129 @@
+# Architecture
+
+Before v0.2.0 the adaptive-sampling cycle was copy-pasted into each of the three
+backends (`pg_omm.py`, `pg_amber.py`, `pg_gmx.py`). Multi-GPU support, a new CV,
+or any algorithm change had to be written three times and could drift. v0.2.0
+extracts the cycle into `pathgennie/core/` behind small protocols, so each
+backend is now just an `Engine` implementation plus a `run()` config loader.
+
+## The cycle (`core/driver.py`)
+
+`PathGennieDriver.run()` implements exactly one loop:
+
+```python
+for cycle in range(max_cycle):
+    trials  = executor.map(worker, range(max_trial))   # N samplers, τ1, fresh velocities
+    metrics = [progress.metric(progress.project(t.coords)) for t in trials]
+    chosen  = trials[softmax_select(metrics, sigma, rng)]
+    runner  = engine.run_segment(chosen.handle, tau2, randomize_velocities=False, ...)
+    anchor  = pick(runner, chosen, anchor)             # optional reject-worse rules
+    if convergence_fn(anchor_coords): break
+```
+
+Key properties baked into the single implementation:
+
+- **Reproducible.** One master `seed` seeds a `numpy.random.Generator` that
+  produces both the per-segment seeds and the selection draw.
+- **Bounded scratch.** Trial handles are released each cycle via
+  `engine.release`, so disk/memory does not grow without bound.
+- **Always saves the converged frame**, even when it does not fall on a
+  `save_freq` boundary.
+- **Adaptive-CV hook.** If the progress object defines `observe(coords, cycle)`,
+  the driver calls it once per cycle (used by SPIB to retrain on the fly).
+- **Restartable seeds.** `run(..., collect_seeds=True)` additionally returns a
+  list of cloned anchor handles aligned with the saved frames — the inputs to a
+  downstream sampling stage.
+
+Constructor:
+
+```python
+PathGennieDriver(engine, progress, convergence_fn, *,
+                 executor=SerialExecutor(), sigma=0.1, seed=None,
+                 reject_worse_tau2=False, reject_worse_anchor=False, verbosity=1)
+```
+
+## The `Engine` protocol (`core/engine.py`)
+
+A backend implements four methods; the driver never inspects a *handle* (an
+opaque token — a restart-file path for the subprocess backends, a state-cache id
+for the in-process ones):
+
+```python
+class Engine(Protocol):
+    def clone_anchor(self, handle) -> handle: ...
+    def run_segment(self, handle, n_steps, *, randomize_velocities, seed, device=None) -> handle: ...
+    def get_coords(self, handle) -> np.ndarray:   # (n_atoms, 3) Angstrom
+        ...
+    def release(self, handle) -> None: ...
+```
+
+`randomize_velocities=True` marks a *sampler* (τ1, fresh Maxwell–Boltzmann
+velocities); `False` marks a *runner* (τ2, continued velocities). `device` is the
+GPU index assigned by the executor.
+
+Implementations: `CoreAmberEngine`, `CoreGromacsEngine`, `OpenMMEngine`, and the
+pure-NumPy `ToyLangevinEngine` (which additionally offers `create_state(coords)`).
+
+## Progress variables (`core/progress.py`)
+
+A `ProgressVariable` couples a CV projection with a scalar metric where **higher
+is better**:
+
+```python
+class ProgressVariable(Protocol):
+    def project(self, coords) -> np.ndarray: ...   # CV vector
+    def metric(self, cv) -> float: ...             # progress score
+```
+
+Built-ins wrap the original backend behaviour verbatim:
+
+- `EscapeMetric(projection_fn, start_cv, escape_metric="distance_from_start"|"cv0")`
+  — maximise distance from the start (or just the first CV component).
+- `TargetMetric(projection_fn, target_cv)` — minimise distance to a target
+  (returned negated).
+
+`CallableProjection` adapts a plain `projection_fn(coords, **kwargs)`.
+`cv.spib.SPIBProgress` is a learned, adaptive implementation (see
+[data-driven-cv.md](data-driven-cv.md)).
+
+## Selection (`core/selection.py`)
+
+`selection_probs(metrics, sigma)` min-max scales the metrics to `[0, 1]` and
+forms weights `exp((scaled − 1)/sigma)` (shifting the max to 0 prevents
+overflow). Small `sigma` → greedy (argmax); large `sigma` → uniform. An
+all-equal batch returns a uniform distribution. `softmax_select(metrics, sigma,
+rng)` draws one index using an explicit `Generator` for reproducibility.
+
+## Parallel execution (`core/parallel.py`)
+
+The driver evaluates the `N` samplers through a `ParallelExecutor`:
+
+```python
+class ParallelExecutor(Protocol):
+    devices: list[int | None]
+    def map(self, worker_fn, items) -> list: ...   # worker_fn(item, device)
+```
+
+- `SerialExecutor(device=None)` — the reference path; `map` runs items in order.
+- `ThreadDevicePool(devices=[0,1,2,3], workers_per_device=1)` — assigns item `i`
+  to `devices[i % len(devices)]` and runs them in a thread pool. Because the
+  subprocess backends spend their time inside `subprocess.run` (GIL released) and
+  each segment exports `CUDA_VISIBLE_DEVICES`, threads genuinely overlap across
+  GPUs. Output order matches input order, and `G=1` reproduces `SerialExecutor`.
+
+See [multi-gpu.md](multi-gpu.md) for usage and benchmarks.
+
+## How a backend wires it together
+
+Each backend `run(case_dir)`:
+
+1. loads `input.yaml` and applies the run profile (`strategy.resolve_profile`);
+2. builds its `Engine` (topology, executable, scratch dir, temperature, …);
+3. builds a `ProgressVariable` from the case's `projection`/`convergence`
+   modules and the `mode` (`escape`/`target`);
+4. builds a `ThreadDevicePool` from `devices`/`workers_per_device`;
+5. constructs a `PathGennieDriver` and calls `run()`;
+6. writes the trajectory + `metrics.csv`.
+
+The OpenMM backend wraps these steps in the `PathGennieMD` adapter; AMBER and
+GROMACS call the driver directly.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,144 @@
+# Configuration reference (`input.yaml`)
+
+Each case is driven by an `input.yaml` with a backend block plus `pathgennie`,
+`projection`, and `convergence` sections. This page documents every key,
+including the ones added in v0.2.0. Keys not listed keep their pre-v0.2.0
+behaviour, and omitting the new keys reproduces the original defaults.
+
+## Top-level layout
+
+```yaml
+workdir: pathgennie_run          # output/scratch root (per backend default)
+
+amber:        { ... }            # exactly one backend block:
+# gromacs:    { ... }            #   amber | gromacs | openmm
+# openmm:     { ... }
+
+pathgennie:   { ... }            # adaptive-sampling settings
+projection:   { ... }            # coords -> CV
+convergence:  { ... }            # when to stop
+md:           { ... }            # optional: MD control overrides
+output:       { ... }            # optional: output file names
+```
+
+## `pathgennie` block
+
+| Key | Type | Default | Meaning |
+|---|---|---|---|
+| `mode` | `escape` \| `target` | `escape` | Directed (`target`) vs blind/escape search. |
+| `tau1_steps` | int | — | Sampler segment length (steps). |
+| `tau2_steps` | int | — | Runner segment length (steps). |
+| `max_trial` | int | — | Swarm size `N` per cycle. |
+| `max_cycle` | int | — | Maximum cycles. |
+| `sigma` | float | — | Selection temperature (small = greedy, large = random). |
+| `temperature` | float | 300 | MD temperature (K). |
+| `save_freq` | int | 10 | Save a frame every this many cycles. |
+| `target_projection` | list[float] | — | Required when `mode: target`. |
+| `escape_metric` | `cv0` \| `distance_from_start` | `cv0` | Escape scoring. |
+| `reject_worse_tau2` | bool | false | Keep the sampler if the runner regresses. |
+| `reject_worse_anchor` | bool | false | Keep the old anchor if the candidate regresses. |
+| **`devices`** | list[int] | none | **v0.2.0** — GPU indices to spread the swarm across. |
+| **`workers_per_device`** | int | 1 | **v0.2.0** — concurrent segments per GPU (replaces `tau1_workers`). |
+| **`seed`** | int | none | **v0.2.0** — master RNG seed (selection + per-segment seeds). |
+| **`profile`** | `discovery` \| `sampling` | none | **v0.2.0** — goal preset; fills defaults below explicit keys. |
+| `tau1_workers` | int | — | Legacy alias for `workers_per_device`. |
+
+### Multi-GPU example
+
+```yaml
+pathgennie:
+  mode: escape
+  tau1_steps: 5
+  tau2_steps: 10
+  max_trial: 10
+  devices: [0, 1, 2, 3]     # 10 samplers spread across 4 GPUs
+  workers_per_device: 1
+  seed: 12345               # reproducible run
+  max_cycle: 5000
+  save_freq: 2
+  sigma: 0.25
+  temperature: 300
+```
+
+### Profiles
+
+`profile` selects a `RunProfile` whose values are used **only where you did not
+set a key explicitly** (explicit always wins). See
+[strategy-profiles.md](strategy-profiles.md).
+
+```yaml
+pathgennie:
+  profile: discovery        # fast candidate paths (greedy, ultrashort, geometric CV)
+  devices: [0, 1]           # explicit keys still override / extend the profile
+```
+
+## `projection` block
+
+```yaml
+projection:
+  module: phi_psi           # a .py file in the case directory
+  function: phi_psi_cv      # called as function(coords, **other_keys)
+  # any additional keys are passed through as kwargs
+```
+
+`module`/`function` name a Python file in the case directory; the remaining keys
+become keyword arguments. The function maps `(n_atoms, 3)` Angstrom coordinates
+to a CV vector.
+
+## `convergence` block
+
+```yaml
+convergence:
+  module: phi_psi
+  function: reached_phi_psi
+  target: [60.0, 40.0]      # extra kwargs passed to the function
+  tolerance: 15.0
+```
+
+The function returns `True` when the path is done.
+
+## `md` block (optional)
+
+Backend-specific MD control overrides, e.g. AMBER `mdin` controls or GROMACS
+`mdp` controls:
+
+```yaml
+md:
+  system: explicit          # AMBER: explicit | implicit | vacuum
+  controls: { ntpr: 0 }     # merged over the backend defaults
+  extra_text: ""            # appended verbatim to mdin (AMBER)
+```
+
+## `output` block (optional)
+
+```yaml
+output:
+  trajectory: reactive_path.dcd
+  metrics: metrics.csv
+  wrap_pbc: false           # AMBER: wrap frames into the primary cell
+```
+
+## Backend blocks (essentials)
+
+```yaml
+amber:
+  topology: system.prmtop
+  initial_restart: start.rst7
+  executable: pmemd.cuda
+  # mpi_launcher / mpi_ranks / mpi_launcher_args (optional)
+
+gromacs:
+  topology: topol.top
+  initial_structure: start.gro
+  mdp: md.mdp
+  executable: gmx
+  # maxwarn / grompp_args / mdrun_args (optional)
+
+openmm:
+  # system/topology files and platform settings (see examples/)
+```
+
+> **Downstream stages (`weighted_ensemble` / `opes`).** A `downstream` field
+> exists on the run profile, but the backend `run()` loaders do **not** yet
+> auto-launch a downstream stage from `input.yaml`. Run Weighted Ensemble through
+> the Python API — see [weighted-ensemble.md](weighted-ensemble.md).

--- a/docs/data-driven-cv.md
+++ b/docs/data-driven-cv.md
@@ -1,0 +1,83 @@
+# Data-driven CVs with SPIB
+
+Instead of a hand-crafted progress variable, PathGennie can learn one on the fly
+with **SPIB** (State Predictive Information Bottleneck; Wang & Tiwary, 2021),
+which jointly learns a low-dimensional CV **and** an emergent set of metastable
+states from the frames a run visits. Requires the `ml` extra (`pip install -e
+.[ml]`, i.e. PyTorch).
+
+## How SPIB works
+
+A predictive information bottleneck:
+
+1. an encoder `q(z|x)` maps a featurized configuration to a Gaussian latent `z`
+   (the CV is its mean);
+2. a classifier `p(y|z)` predicts, from `z_t`, the *future* metastable-state
+   label `y_{t+dt}`;
+3. training minimises `CE(p(y|z_t), y_{t+dt}) + β·KL(q(z|x)||prior)` — the IB
+   trade-off between being predictive and being compressed;
+4. state labels are refined self-consistently: after each round every frame is
+   relabelled by `argmax p(y|z)`, empty states are dropped, and the **number of
+   metastable states emerges from the data**.
+
+## Featurization (`pathgennie/cv/features.py`, NumPy)
+
+```python
+from pathgennie.cv.features import Featurizer, pairwise_distances, contact_features, dihedral_features
+
+feat = Featurizer(funcs=[
+    lambda c: pairwise_distances(c, [[4, 6], [6, 8]]),
+    lambda c: dihedral_features(c, [[4, 6, 8, 14]]),
+], standardize=True)
+feat.fit(frames)            # accumulate online mean/std
+X = feat.transform_batch(frames)
+```
+
+`Featurizer` with no `funcs` uses the flattened coordinates (handy for the toy
+system). Featurization is pure NumPy and has no heavy dependency.
+
+## Training a model directly
+
+```python
+from pathgennie.cv.spib import train_spib
+result = train_spib(features,            # (n_frames, n_features), time-ordered
+                    dt=1, n_states_init=6, latent_dim=2, beta=1e-3,
+                    epochs=60, n_refine=6, seed=0)
+result.model        # SPIB encoder/classifier
+result.labels       # per-frame metastable-state ids
+result.n_states     # emergent number of states
+```
+
+## Driving PathGennie with a learned CV
+
+`SPIBProgress` is an adaptive `ProgressVariable`: it bootstraps from a coarse
+geometric CV, buffers the path the driver visits, retrains periodically (the
+"iterative path-learning cycle"), then steers using the learned latent.
+
+```python
+from pathgennie.cv.features import Featurizer
+from pathgennie.cv.spib import SPIBProgress
+from pathgennie.core.progress import TargetMetric
+
+bootstrap = TargetMetric(my_geometric_cv, target_cv=target)
+progress = SPIBProgress(
+    Featurizer(funcs=my_feature_fns),
+    bootstrap,
+    mode="target", target_coords=target_coords,
+    refresh_every=50, min_frames=40, dt=1,
+    train_kwargs=dict(n_states_init=6, latent_dim=2, epochs=40),
+)
+# pass `progress` to PathGennieDriver as usual
+```
+
+The driver calls `progress.observe(coords, cycle)` once per cycle (a no-op for
+static CVs), which is how SPIB accumulates frames and retrains. After a refresh,
+`progress.n_states` and `progress.state_labels` expose the metastable states —
+these feed the [roadmap graph](roadmap-graph.md).
+
+## Trajectory length matters
+
+A learned CV needs segments long enough to contain real relaxation. If you are in
+the ultrashort `discovery` regime, see the guard in
+[strategy-profiles.md](strategy-profiles.md); prefer the `sampling` profile (or
+longer `tau1`/`tau2`) when learning a CV for quantitative work.

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,16 +18,22 @@ chronological list of changes see [`CHANGELOG.md`](../CHANGELOG.md).
 - [Architecture](architecture.md) — the core driver, the `Engine` protocol,
   progress variables, and the parallel executor.
 - [Configuration](configuration.md) — the full `input.yaml` schema, including the
-  new `devices` / `workers_per_device` / `seed` / `profile` keys.
+  new `devices` / `workers_per_device` / `seed` / `profile` / `downstream` keys.
 - [Multi-GPU scalability](multi-gpu.md) — how the device pool spreads the swarm
   across GPUs, and how to benchmark it.
 - [Strategy profiles](strategy-profiles.md) — switching behaviour by *goal*
   (`discovery` vs `sampling`) and the learned-CV trajectory-length guard.
 - [Data-driven CVs (SPIB)](data-driven-cv.md) — learning a CV and metastable
   states on the fly.
-- [Weighted Ensemble](weighted-ensemble.md) — the path-informed downstream
-  free-energy / rate-constant stage.
-- [Roadmap](roadmap.md) — what is implemented vs planned.
+- [Non-linear search (RRT)](non-linear-search.md) — RRT / RRT-Connect for
+  pathways the greedy metric cannot follow.
+- [Roadmap graph](roadmap-graph.md) — all-pairs pathways between metastable
+  states (Dijkstra + Yen).
+- [Agentic controller](agent.md) — automating swarm size and segment lengths.
+- [Weighted Ensemble](weighted-ensemble.md) — path-informed free-energy /
+  rate-constant stage.
+- [OPES via PLUMED](opes.md) — free-energy surfaces along a CV.
+- [Project roadmap](roadmap.md) — what is implemented vs planned.
 
 **Tutorials** (all runnable with no MD binary or GPU unless noted)
 - [01 — Quickstart on the toy engine](tutorials/01-quickstart-toy.md)
@@ -35,6 +41,9 @@ chronological list of changes see [`CHANGELOG.md`](../CHANGELOG.md).
 - [03 — A learned CV with SPIB](tutorials/03-spib-cv.md)
 - [04 — Free energies & rates with Weighted Ensemble](tutorials/04-weighted-ensemble.md)
 - [05 — Goal-driven strategy profiles](tutorials/05-strategy-profiles.md)
+- [06 — Non-linear search with RRT-Connect](tutorials/06-rrt-search.md)
+- [07 — Metastable states, roadmap & the agent](tutorials/07-roadmap-agent.md)
+- [08 — Free-energy surfaces with OPES](tutorials/08-opes.md)
 
 ## Installation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,80 @@
+# PathGennie Manual
+
+PathGennie is a **direction-guided adaptive sampling** method for molecular
+dynamics. From an anchor configuration it launches a *swarm* of short, unbiased
+MD segments, scores each by progress in a collective-variable (CV) space,
+softmax-selects one, extends it, updates the anchor, and repeats — generating
+rare-event pathways (ligand unbinding, (un)folding, conformational change)
+cheaply, with only a *selection* bias on natural dynamics (no bias potential).
+
+This manual documents the v0.2.0 architecture and the features added on top of
+the original three-backend runners. For a high-level project overview and the
+example gallery, see the top-level [`README.md`](../README.md); for a
+chronological list of changes see [`CHANGELOG.md`](../CHANGELOG.md).
+
+## Contents
+
+**Reference**
+- [Architecture](architecture.md) — the core driver, the `Engine` protocol,
+  progress variables, and the parallel executor.
+- [Configuration](configuration.md) — the full `input.yaml` schema, including the
+  new `devices` / `workers_per_device` / `seed` / `profile` keys.
+- [Multi-GPU scalability](multi-gpu.md) — how the device pool spreads the swarm
+  across GPUs, and how to benchmark it.
+- [Strategy profiles](strategy-profiles.md) — switching behaviour by *goal*
+  (`discovery` vs `sampling`) and the learned-CV trajectory-length guard.
+- [Data-driven CVs (SPIB)](data-driven-cv.md) — learning a CV and metastable
+  states on the fly.
+- [Weighted Ensemble](weighted-ensemble.md) — the path-informed downstream
+  free-energy / rate-constant stage.
+- [Roadmap](roadmap.md) — what is implemented vs planned.
+
+**Tutorials** (all runnable with no MD binary or GPU unless noted)
+- [01 — Quickstart on the toy engine](tutorials/01-quickstart-toy.md)
+- [02 — Multi-GPU runs on the MD backends](tutorials/02-multi-gpu.md)
+- [03 — A learned CV with SPIB](tutorials/03-spib-cv.md)
+- [04 — Free energies & rates with Weighted Ensemble](tutorials/04-weighted-ensemble.md)
+- [05 — Goal-driven strategy profiles](tutorials/05-strategy-profiles.md)
+
+## Installation
+
+```bash
+pip install -e .            # core (OpenMM backend deps included)
+pip install -e .[dev]       # + pytest
+pip install -e .[ml]        # + PyTorch, required for the SPIB data-driven CV
+pip install -e .[examples]  # + ParmEd for some example setups
+```
+
+Run the test suite to confirm a working install:
+
+```bash
+pytest -q                   # 47 tests; SPIB tests skip if torch is absent
+```
+
+## The 60-second mental model
+
+```
+                ┌─────────────────────────── PathGennieDriver ───────────────────────────┐
+ anchor ──▶ clone ─▶ run N samplers (τ1) ─▶ project→metric ─▶ softmax_select ─▶ runner (τ2)
+                          │  (ParallelExecutor: 1..G GPUs)        │ (selection.py)     │
+                          ▼                                       ▼                    ▼
+                    Engine.run_segment                     ProgressVariable      update anchor → repeat
+   (OpenMM / AMBER / GROMACS / toy)             (geometric Escape/Target, or learned SPIB)
+                                                                                       │
+                                                              ┌────────────────────────┘
+                                                              ▼
+                                       PathEnsemble ──▶ SamplingStage (Weighted Ensemble) ──▶ FES / rates
+```
+
+Every box is a small, swappable interface:
+
+| Concern | Interface | Built-ins |
+|---|---|---|
+| MD engine | `core.engine.Engine` | OpenMM, AMBER, GROMACS, `ToyLangevinEngine` |
+| Progress / CV | `core.progress.ProgressVariable` | `EscapeMetric`, `TargetMetric`, `cv.spib.SPIBProgress` |
+| Parallelism | `core.parallel.ParallelExecutor` | `SerialExecutor`, `ThreadDevicePool` |
+| Goal preset | `core.strategy.RunProfile` | `discovery`, `sampling` |
+| Downstream | `sampling.base.SamplingStage` | `WeightedEnsembleStage` |
+
+Because these are protocols, you can mix any engine with any CV, any degree of
+parallelism, and any downstream stage without touching the others.

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,8 @@ chronological list of changes see [`CHANGELOG.md`](../CHANGELOG.md).
 - [Weighted Ensemble](weighted-ensemble.md) — path-informed free-energy /
   rate-constant stage.
 - [OPES via PLUMED](opes.md) — free-energy surfaces along a CV.
+- [Path sampling (TPS/TIS)](path-sampling.md) — kinetics via OpenPathSampling
+  on PathGennie seed paths.
 - [Project roadmap](roadmap.md) — what is implemented vs planned.
 - [Future roadmap](../ROADMAP.md) — strategic plan toward a PLUMED/WESTPA-class
   framework (tiers, milestones, priority queue).
@@ -46,6 +48,7 @@ chronological list of changes see [`CHANGELOG.md`](../CHANGELOG.md).
 - [06 — Non-linear search with RRT-Connect](tutorials/06-rrt-search.md)
 - [07 — Metastable states, roadmap & the agent](tutorials/07-roadmap-agent.md)
 - [08 — Free-energy surfaces with OPES](tutorials/08-opes.md)
+- [09 — Kinetics with TPS/TIS (OpenPathSampling)](tutorials/09-path-sampling.md)
 
 ## Installation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,6 +34,8 @@ chronological list of changes see [`CHANGELOG.md`](../CHANGELOG.md).
   rate-constant stage.
 - [OPES via PLUMED](opes.md) — free-energy surfaces along a CV.
 - [Project roadmap](roadmap.md) — what is implemented vs planned.
+- [Future roadmap](../ROADMAP.md) — strategic plan toward a PLUMED/WESTPA-class
+  framework (tiers, milestones, priority queue).
 
 **Tutorials** (all runnable with no MD binary or GPU unless noted)
 - [01 — Quickstart on the toy engine](tutorials/01-quickstart-toy.md)

--- a/docs/multi-gpu.md
+++ b/docs/multi-gpu.md
@@ -1,0 +1,87 @@
+# Multi-GPU scalability
+
+PathGennie's swarm is embarrassingly parallel: the `N` sampler segments in a
+cycle are independent. v0.2.0 spreads them across every GPU on the machine
+through one backend-agnostic abstraction, the `ParallelExecutor`.
+
+## What was wrong before
+
+The AMBER/GROMACS backends launched their swarm through a bare
+`ThreadPoolExecutor` with **no device assignment**, so every worker inherited the
+same environment and contended for GPU 0; the extra GPUs sat idle. Trials also
+wrote files with colliding names into a single scratch directory.
+
+## How it works now
+
+`ThreadDevicePool` round-robins trial `i` onto `devices[i % len(devices)]` and
+runs them in a thread pool. Each MD segment:
+
+- exports `CUDA_VISIBLE_DEVICES=<device>` for its assigned GPU, and
+- writes into an **isolated per-device scratch subdirectory** (`dev0/`, `dev1/`,
+  …) with a unique file stem.
+
+The subprocess backends (`pmemd.cuda`, `gmx mdrun`) spend their wall-time inside
+`subprocess.run`, which releases the GIL, so the threads genuinely run
+concurrently across GPUs. For the in-process OpenMM engine, construct one engine
+per worker process (one CUDA context per GPU).
+
+`SerialExecutor` is the single-device reference path; with one device a
+`ThreadDevicePool` reproduces it exactly for a fixed seed.
+
+## Enabling it
+
+In `input.yaml`:
+
+```yaml
+pathgennie:
+  max_trial: 16
+  devices: [0, 1, 2, 3]     # spread 16 samplers across 4 GPUs
+  workers_per_device: 1     # raise for small systems that under-fill a GPU
+  seed: 42
+```
+
+`workers_per_device` allows more than one concurrent segment per GPU (useful when
+a single small system cannot saturate a card). The legacy `tau1_workers` key is
+still accepted as an alias.
+
+## In Python
+
+```python
+from pathgennie.core.parallel import ThreadDevicePool, SerialExecutor
+from pathgennie.core.driver import PathGennieDriver
+
+executor = ThreadDevicePool(devices=[0, 1, 2, 3], workers_per_device=2)
+driver = PathGennieDriver(engine, progress, convergence_fn,
+                          executor=executor, sigma=0.2, seed=7)
+# ... driver.run(...)
+```
+
+## Reproducibility
+
+A single master `seed` seeds the driver's RNG, which produces both the selection
+draw and every per-segment seed. With a deterministic integrator, `G`-device and
+serial runs match bit-for-bit. (A stochastic thermostat's noise stream is not
+reliably re-seedable per segment in OpenMM, so only the selection/velocity draws
+are guaranteed reproducible there — see `backends/openmm/engine.py`.)
+
+## Benchmarking
+
+`benchmarks/scaling.py` measures cycles/second versus the number of devices using
+a GIL-releasing sleep engine that models a GPU segment of a known cost, so the
+dispatch overhead of the executor itself is what's measured:
+
+```bash
+python benchmarks/scaling.py --devices 1 2 4 8 --max-trial 16 --max-cycle 20 --segment-ms 15
+```
+
+Representative output (overhead-dominated toy, not a physics result):
+
+```
+ devices   wall (s)   cycles/s   speedup
+       1      3.894       3.85      1.00x
+       2      2.080       7.21      1.87x
+       4      1.170      12.82      3.33x
+       8      0.730      20.54      5.33x
+```
+
+Real speedup is bounded by `min(N, G)` and by the serial runner (τ2) step.

--- a/docs/non-linear-search.md
+++ b/docs/non-linear-search.md
@@ -1,0 +1,69 @@
+# Non-linear path search (RRT / RRT-Connect)
+
+The greedy driver follows a monotone progress metric, so it cannot backtrack,
+change direction, or move orthogonally to the CV — the failure mode the paper
+shows on Wolfe–Quapp. `pathgennie/search/rrt.py` reframes each expansion as
+growing a **Rapidly-exploring Random Tree** in CV space.
+
+## Algorithm
+
+Each iteration:
+
+1. sample a random CV target `q_rand` (occasionally the goal — *goal biasing*);
+2. find the nearest existing tree node `q_near` (by CV distance);
+3. run a PathGennie swarm from `q_near` and select the sampler whose CV moves
+   closest to `q_rand` — the existing `softmax_select` with metric
+   `-||cv - q_rand||`;
+4. extend the chosen sampler with a `tau2` runner and add it as a new node.
+
+Because targets point in any CV direction and the tree remembers every node, the
+search backtracks and explores naturally. **RRT-Connect** grows two trees — from
+the start and from a goal configuration — and links them, crossing barriers much
+faster. Everything reuses the shared `Engine` and `ParallelExecutor`, so RRT is
+multi-GPU and backend-agnostic.
+
+## RRT
+
+```python
+from pathgennie.core.toy import ToyLangevinEngine
+from pathgennie.core.parallel import SerialExecutor
+from pathgennie.search.rrt import RRT
+import numpy as np
+
+engine = ToyLangevinEngine(dt=0.005, kT=1.0)
+start = engine.create_state((-1.174, 1.477))           # basin A
+rrt = RRT(engine, lambda c: np.array([c[0, 0], c[0, 1]]),
+          lower=[-2, -2], upper=[2, 2],
+          tau1=5, tau2=10, n_expand=8, sigma=0.05, goal_bias=0.2,
+          executor=SerialExecutor(), seed=0)
+result = rrt.build(start, target_cv=[1.124, -1.485], max_iter=300, goal_tol=0.5)
+
+result.success          # reached the target basin?
+result.path             # list[Node] root -> goal, each with .cv, .handle, .parent
+result.tree_size
+```
+
+With `target_cv=None`, `build` grows an exploratory tree for `max_iter`
+expansions (blind exploration).
+
+## RRT-Connect
+
+```python
+from pathgennie.search.rrt import rrt_connect
+goal = engine.create_state((1.124, -1.485))            # basin B
+result = rrt_connect(engine, lambda c: np.array([c[0, 0], c[0, 1]]),
+                     start, goal, lower=[-2, -2], upper=[2, 2],
+                     tau1=5, tau2=10, n_expand=8, executor=SerialExecutor(),
+                     seed=2, max_iter=300, connect_tol=0.6)
+result.path             # joined start -> goal path
+```
+
+## Notes
+
+- CV space is whatever `cv_fn(coords) -> vector` you pass — a geometric CV or the
+  learned SPIB latent. `lower`/`upper` bound the random-target sampling box.
+- Tree nodes keep their engine handles alive (they *are* the backtracking memory);
+  only discarded swarm trials are released each expansion.
+- The `ExplorerPolicy` protocol in `pathgennie/core/policy.py` is the shared
+  abstraction (`GreedyPolicy` reproduces the driver); RRT/RRT-Connect are the
+  non-linear policies.

--- a/docs/opes.md
+++ b/docs/opes.md
@@ -1,0 +1,77 @@
+# OPES (free-energy surfaces) via PLUMED
+
+OPES (On-the-fly Probability Enhanced Sampling; Invernizzi & Parrinello, 2020)
+deposits an adaptive bias along a CV so the system samples a flatter
+distribution, from which the free-energy surface is recovered by reweighting. In
+production this is driven by **PLUMED** (<https://www.plumed.org/>) patched into
+the MD engine; PathGennie supplies the CV definition, OPES parameters, and seed
+configurations from a `PathEnsemble`.
+
+`pathgennie/sampling/opes.py` provides two layers.
+
+## 1. PLUMED interface (production)
+
+`build_plumed_opes_input` generates a `plumed.dat` with an `OPES_METAD` action,
+and `OPESStage(mode="plumed")` drives a PLUMED-capable engine:
+
+```python
+from pathgennie.sampling.opes import build_plumed_opes_input, OPESStage
+
+text = build_plumed_opes_input(
+    ["phi: TORSION ATOMS=5,7,9,15", "psi: TORSION ATOMS=7,9,15,17"],
+    ["phi", "psi"], pace=500, barrier=40.0, temp=300.0, sigma=[0.1, 0.1],
+)
+
+stage = OPESStage(mode="plumed",
+                  plumed_cv_definitions=["phi: TORSION ATOMS=5,7,9,15"],
+                  plumed_arg_names=["phi"], pace=500, barrier=40.0)
+# stage.run(ensemble, engine) calls engine.run_plumed(plumed_input, ensemble, ...)
+```
+
+`OPESStage(mode="plumed")` requires the engine to expose
+`run_plumed(plumed_input, ensemble, **cfg)`. The current MD engines do **not**
+yet implement it, so a PLUMED-patched engine must be supplied; otherwise the stage
+raises an informative `NotImplementedError`. This is the documented integration
+point for AMBER/GROMACS/OpenMM + PLUMED.
+
+## 2. Verifiable OPES core (toy)
+
+So the OPES *algorithm* (not just the interface) is testable in CI, the module
+includes a dependency-free implementation on an analytic potential:
+
+- `OPESBias` — adaptive well-tempered kernel bias along a 1-D CV (the
+  `OPES_METAD` core: kernels deposited with well-tempered heights; bias capped at
+  `-barrier`).
+- `OPESSimulation` — biased over-damped Langevin on a `grad_fn(pos)` potential,
+  with reweighted-histogram FES recovery.
+
+```python
+import numpy as np
+from pathgennie.core.toy import wolfe_quapp_gradient
+from pathgennie.sampling.opes import OPESBias, OPESSimulation
+
+bias = OPESBias(kT=2.0, gamma=15.0, sigma=0.2, barrier=8.0)
+sim = OPESSimulation(wolfe_quapp_gradient, cv_axis=1, kT=2.0, dt=0.005, pace=20, bias=bias)
+samples = sim.run(np.array([-1.0, -1.4]), n_steps=20000)
+fe = sim.fes(samples, np.linspace(-2, 2, 33))   # recovers the WQ y-marginal
+```
+
+`OPESStage(mode="toy", potential_grad=..., cv_axis=...)` wraps this behind the
+`SamplingStage` contract for end-to-end use on toy systems. The bias-update and
+reweighting maths are identical to the production path; only the propagator
+differs.
+
+## From `input.yaml`
+
+```yaml
+pathgennie:
+  downstream: opes
+opes:
+  mode: plumed
+  plumed_cv_definitions: ["phi: TORSION ATOMS=5,7,9,15"]
+  plumed_arg_names: ["phi"]
+  pace: 500
+  barrier: 40.0
+```
+
+This requires a PLUMED-capable engine (see above).

--- a/docs/path-sampling.md
+++ b/docs/path-sampling.md
@@ -1,0 +1,89 @@
+# Path sampling (TPS / TIS) via OpenPathSampling
+
+Transition Path Sampling (TPS) and Transition Interface Sampling (TIS) are an
+*alternative to Weighted Ensemble* for computing kinetics. Both need an initial
+reactive A→B trajectory to bootstrap — exactly what a PathGennie run produces.
+`pathgennie/sampling/path_sampling.py` bridges a discovered `PathEnsemble` to
+[OpenPathSampling](https://openpathsampling.org/) (OPS).
+
+Install the optional dependency: `pip install -e .[pathsampling]` (i.e.
+`openpathsampling`).
+
+## Two layers (same pattern as the OPES module)
+
+**1. Dependency-free seed preparation** (always available, fully tested) — turn a
+discovered path into an OPS-ready seed:
+
+```python
+import numpy as np
+from pathgennie.sampling import build_path_ensemble
+from pathgennie.sampling.path_sampling import (
+    CVRangeState, label_frames, extract_transition_path, tis_interfaces, prepare_ops_seed,
+)
+
+cv = lambda c: c[0, 1]                      # scalar progress coordinate
+A = CVRangeState("A", -2.0, -1.0)          # states as CV intervals
+B = CVRangeState("B",  1.0,  2.0)
+
+ens = build_path_ensemble(frames, metrics)  # from driver.run(...)
+span = extract_transition_path(ens.frames, cv, A, B)   # (start, end) of the A->B sub-path
+seed = prepare_ops_seed(ens, cv, A, B, interfaces=tis_interfaces(-1.0, 1.0, 6))
+seed["reactive"], seed["seed_frames"].shape, seed["interfaces"]
+```
+
+- `CVRangeState` — a state as a closed CV interval.
+- `label_frames` / `extract_transition_path` / `is_reactive` — label frames and
+  slice the minimal reactive sub-path (from the last A frame before the first
+  subsequent B frame).
+- `tis_interfaces(lambda0, lambdaN, n, spacing="linear"|"exp")` — lay out TIS
+  interfaces (exp packs them where crossing probabilities change fastest).
+- `prepare_ops_seed` — bundles all of the above into the dict OPS needs.
+
+**2. OPS-dependent stage** — `PathSamplingStage` (implements `SamplingStage`):
+
+```python
+import openpathsampling as paths
+from openpathsampling.engines.openmm import Engine as OPSEngine   # OPS's own engine
+from pathgennie.sampling import make_stage
+
+ops_engine = OPSEngine(...)                 # build per OPS docs (topology, system, integrator)
+
+# TPS:
+stage = make_stage("tps", cv_fn=cv, state_a=(-2, -1), state_b=(1, 2),
+                   ops_engine=ops_engine, n_steps=2000, storage_path="tps.nc")
+result = stage.run(ens, engine=None)        # OPS propagates with ops_engine
+
+# TIS (rate constants):
+stage = make_stage("tis", cv_fn=cv, state_a=(-2, -1), state_b=(1, 2),
+                   interfaces=list(tis_interfaces(-1.0, 1.0, 6)),
+                   ops_engine=ops_engine, n_steps=5000)
+result = stage.run(ens, engine=None)
+result.rate_constants    # {"rate_matrix": ...} from OPS TISAnalysis
+```
+
+`PathSamplingStage` builds the OPS CV (`CoordinateFunctionCV`), state volumes
+(`CVDefinedVolume`), the network (`TPSNetwork` / `MISTISNetwork`), a one-way
+shooting move scheme, seeds it with the extracted reactive sub-path, runs
+`PathSampling`, and returns kinetics in a `SamplingResult`.
+
+## Important: OPS uses its own engine
+
+OPS propagates shooting moves with **its own** engine (e.g.
+`openpathsampling.engines.openmm`), not PathGennie's swarm `Engine`. So you pass
+`ops_engine=`; the PathGennie engine argument to `run` is unused. Without
+`openpathsampling` installed, or without an `ops_engine`, the stage raises an
+informative error. The bridge targets the OpenPathSampling 1.x API and cannot be
+executed in a CPU-only sandbox, so only the dependency-free preparation is
+covered by CI.
+
+## When to use TPS/TIS vs Weighted Ensemble
+
+| | Weighted Ensemble | TPS / TIS (OPS) |
+|---|---|---|
+| What it gives | FES + steady-state rate | transition path ensemble; rate (TIS) |
+| Bias | none (resampling weights) | none (shooting moves) |
+| Best when | broad CV coverage / FES wanted | mechanism + rate of a known A→B event |
+| PathGennie role | informed seeds + bins | informed initial reactive path |
+
+Both consume the same `PathEnsemble`, so you can run either (or both) on one
+discovery run.

--- a/docs/roadmap-graph.md
+++ b/docs/roadmap-graph.md
@@ -1,0 +1,43 @@
+# Roadmap graph & all-pairs pathways
+
+RRT and the swarm discover *transitions*; the roadmap turns the accumulated
+transitions into a global weighted graph and extracts pathways between metastable
+states. Nodes are states (e.g. SPIB metastable-state labels), and a directed edge
+`u → v` is weighted by `-log(transition fraction)` — a free-energy-like cost, so
+the *minimum-cost* path is the *maximum-likelihood / minimum-free-energy* route.
+
+`pathgennie/search/roadmap.py` is pure standard library (no graph dependency).
+
+## Building a roadmap
+
+```python
+from pathgennie.search.roadmap import Roadmap
+
+rm = Roadmap()
+# Feed a state-label trajectory (e.g. SPIBProgress.state_labels), or add edges:
+rm.observe_sequence([0, 0, 1, 1, 2, 1, 0, 1, 2])
+rm.add_transition(0, 2, count=1.0)
+
+rm.nodes                       # discovered states
+adj = rm.adjacency()           # {u: {v: -log p(u->v)}}
+```
+
+## Extracting pathways
+
+```python
+cost, path = rm.min_free_energy_path(0, 2)     # Dijkstra: single best route
+routes = rm.k_shortest_paths(0, 2, k=3)        # Yen: competing parallel routes
+report = rm.all_pairs_paths(k=1)               # {(s, t): [(cost, path), ...]}
+```
+
+- `dijkstra_path(adj, s, t)` — minimum-cost path; `(inf, [])` if unreachable.
+- `k_shortest_paths(adj, s, t, k)` — Yen's algorithm: up to `k` loopless paths in
+  increasing cost, formalising the paper's competing egress-route clustering.
+
+## Where the states come from
+
+Pair this with [SPIB](data-driven-cv.md): after a refresh, `SPIBProgress`
+provides `state_labels` (per-frame metastable-state ids). Feeding that label
+trajectory to `observe_sequence` builds a roadmap whose nodes are *learned*
+metastable states — no separate clustering step. The per-edge `-log(fraction)`
+weights are also ready to seed Weighted Ensemble or an MSM.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,45 @@
+# Roadmap: implemented vs planned
+
+A snapshot of what the v0.2.0 codebase delivers and what remains, against the
+development plan.
+
+## Implemented (verified in CI on toy/synthetic systems)
+
+| Area | Module(s) | Verification |
+|---|---|---|
+| Shared core driver | `core/driver.py`, `engine.py`, `progress.py`, `selection.py` | full-driver smoke test on the toy engine |
+| Multi-GPU device pool | `core/parallel.py`, backend `engine.py` | per-backend device-dispatch tests; G=1 ≡ serial |
+| Toy Wolfe–Quapp engine | `core/toy.py` | used throughout the suite |
+| Strategy profiles | `core/strategy.py` | profile-resolution + guard tests |
+| Data-driven CV (SPIB) | `cv/features.py`, `cv/spib.py` | 2-state recovery + driver integration |
+| Non-linear search (RRT/Connect) | `search/rrt.py`, `core/policy.py` | RRT reaches the opposite WQ basin; Connect links both |
+| Roadmap graph | `search/roadmap.py` | Dijkstra + Yen k-shortest correctness |
+| Agentic controller | `agent/controller.py` | escalate/relax/stop/frontier rules |
+| Weighted Ensemble | `sampling/weighted_ensemble.py` | weight conservation + WQ FES recovery |
+| OPES (core + PLUMED interface) | `sampling/opes.py` | toy WQ marginal recovery; PLUMED input generation |
+| Downstream wiring | `sampling/runner.py`, backends | toy `run_downstream` test |
+
+Run `pytest -q` to reproduce (69 tests; SPIB tests need the `ml` extra).
+
+## Environment caveats (not runnable in a CPU-only sandbox)
+
+These code paths are implemented and exercised through the shared, tested helpers,
+but a live run needs hardware/binaries unavailable here:
+
+- **Real-MD multi-GPU runs** of the AMBER (`pmemd.cuda`) and GROMACS (`gmx
+  mdrun`) backends.
+- **Downstream stages launched from a real backend** (WE/OPES on solvated systems
+  via `pathgennie.downstream`).
+- **OPES on real MD**, which needs a **PLUMED-patched engine** exposing
+  `run_plumed` (see [opes.md](opes.md)).
+
+## Planned / future work
+
+- A `run_plumed` capability on the MD engines (PLUMED patch / `CustomCVForce`) so
+  `OPESStage(mode="plumed")` runs end-to-end on real systems.
+- RRT\* rewiring of the roadmap (edge cost = `-log(transition fraction)`) to bias
+  toward minimum-free-energy tubes.
+- A learning controller (contextual bandit / RL) and an optional LLM
+  meta-controller behind the existing `Controller` surface.
+- Process-pool OpenMM execution (one CUDA context per GPU) for in-process
+  multi-GPU.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -17,6 +17,7 @@ development plan.
 | Agentic controller | `agent/controller.py` | escalate/relax/stop/frontier rules |
 | Weighted Ensemble | `sampling/weighted_ensemble.py` | weight conservation + WQ FES recovery |
 | OPES (core + PLUMED interface) | `sampling/opes.py` | toy WQ marginal recovery; PLUMED input generation |
+| Path sampling (TPS/TIS) bridge | `sampling/path_sampling.py` | seed prep / reactive-path extraction / interfaces (OPS run needs the `pathsampling` extra) |
 | Downstream wiring | `sampling/runner.py`, backends | toy `run_downstream` test |
 
 Run `pytest -q` to reproduce (69 tests; SPIB tests need the `ml` extra).
@@ -32,6 +33,9 @@ but a live run needs hardware/binaries unavailable here:
   via `pathgennie.downstream`).
 - **OPES on real MD**, which needs a **PLUMED-patched engine** exposing
   `run_plumed` (see [opes.md](opes.md)).
+- **TPS/TIS runs**, which need the `pathsampling` extra (`openpathsampling`) and
+  an OPS engine; only the dependency-free seed preparation is CI-tested (see
+  [path-sampling.md](path-sampling.md)).
 
 ## Planned / future work
 

--- a/docs/strategy-profiles.md
+++ b/docs/strategy-profiles.md
@@ -1,0 +1,57 @@
+# Strategy profiles
+
+PathGennie's original regime — greedy selection on **ultrashort** (tens of fs)
+trajectories — is tuned for *fast candidate-path discovery*. A learned CV (SPIB)
+and downstream free-energy/kinetics work generally need **longer** segments and
+more data. Rather than hard-code one regime, a `RunProfile` bundles the choices
+that should move together for a goal, and you switch behaviour with a single key.
+
+## Presets (`pathgennie/core/strategy.py`)
+
+| Profile | goal | selection | cv | tau1 | tau2 | max_trial | sigma | downstream |
+|---|---|---|---|---|---|---|---|---|
+| `discovery` | discovery | softmax | geometric | 2 | 8 | 15 | 0.1 | none |
+| `sampling` | sampling | beam | learned | 50 | 100 | 20 | 0.2 | weighted_ensemble |
+
+- **`discovery`** — the original PathGennie: cheap, greedy, geometric CV. Best for
+  quickly enumerating candidate routes to seed later sampling.
+- **`sampling`** — longer segments, a learned CV is permitted, and the run is set
+  up to feed an enhanced-sampling stage. Best when the goal is a quantitative FES
+  or rate.
+
+## How resolution works
+
+`resolve_profile(pg_cfg)` overlays the named profile's values **underneath**
+whatever you set explicitly — explicit always wins, and omitting `profile`
+returns the config unchanged (so old cases are unaffected). All three backends
+apply it.
+
+```yaml
+pathgennie:
+  profile: discovery     # fills tau1/tau2/max_trial/sigma/selection/cv/downstream
+  max_trial: 24          # ...but this explicit value overrides the profile's 15
+  devices: [0, 1, 2, 3]
+```
+
+In Python:
+
+```python
+from pathgennie.core.strategy import resolve_profile, get_profile
+cfg = resolve_profile({"profile": "sampling", "tau1_steps": 30})
+# cfg["tau1_steps"] == 30 (explicit), cfg["cv"] == "learned" (from profile)
+```
+
+## The learned-CV trajectory-length guard
+
+A learned CV needs trajectories long enough to contain real relaxation.
+`check_learned_cv_segment_length(tau1, tau2, timestep_ps, min_ps=0.1)` warns (and
+returns `False`) when the per-cycle MD time `(tau1+tau2)·dt` is below `min_ps`,
+flagging the ultrashort-vs-learned-CV mismatch the discovery regime can introduce:
+
+```python
+from pathgennie.core.strategy import check_learned_cv_segment_length
+check_learned_cv_segment_length(2, 8, timestep_ps=0.002)   # -> warns, returns False
+check_learned_cv_segment_length(50, 100, timestep_ps=0.002) # -> True
+```
+
+It is advisory — the run still proceeds — so you stay in control of the trade-off.

--- a/docs/tutorials/01-quickstart-toy.md
+++ b/docs/tutorials/01-quickstart-toy.md
@@ -1,0 +1,53 @@
+# Tutorial 01 — Quickstart on the toy engine
+
+This runs the *entire* PathGennie driver — swarm → selection → runner →
+convergence — with no MD binary or GPU, using the built-in Wolfe–Quapp toy
+engine. It's the fastest way to see the method work and the foundation every
+other tutorial builds on.
+
+## Run it
+
+```python
+import numpy as np
+from pathgennie.core.driver import PathGennieDriver
+from pathgennie.core.parallel import SerialExecutor
+from pathgennie.core.progress import TargetMetric
+from pathgennie.core.toy import ToyLangevinEngine
+
+# 1) An engine (2-D Langevin on the Wolfe-Quapp surface).
+engine = ToyLangevinEngine(dt=0.005, kT=1.0)
+initial = engine.create_state((-1.174, 1.477))     # basin A
+
+# 2) A progress variable: aim at basin B in (x, y) CV space.
+xy = lambda coords: np.array([coords[0, 0], coords[0, 1]])
+progress = TargetMetric(xy, target_cv=np.array([1.124, -1.485]))
+
+# 3) Stop when we're close to the target basin.
+def converged(coords):
+    return np.linalg.norm(xy(coords) - np.array([1.124, -1.485])) < 0.4
+
+# 4) Drive it.
+driver = PathGennieDriver(engine, progress, converged,
+                          executor=SerialExecutor(), sigma=0.2, seed=0)
+traj, metrics = driver.run(initial, tau1=5, tau2=10, max_trial=8,
+                           max_cycle=400, save_freq=5)
+
+print("saved frames:", traj.shape[0])
+print("final CV:", xy(traj[-1]))
+```
+
+You'll see the metric improve cycle by cycle and the run converge once it reaches
+basin B.
+
+## What just happened
+
+- `max_trial=8` samplers each ran a `tau1=5`-step segment with fresh velocities.
+- Each was scored by `progress`, and one was `softmax`-selected (`sigma=0.2`).
+- The winner was extended for a `tau2=10`-step runner and became the new anchor.
+- `seed=0` makes the whole run reproducible.
+
+## Next
+
+- Spread the swarm across GPUs → [02 — Multi-GPU](02-multi-gpu.md).
+- Replace the hand-written CV with a learned one → [03 — SPIB](03-spib-cv.md).
+- Turn the path into a free energy → [04 — Weighted Ensemble](04-weighted-ensemble.md).

--- a/docs/tutorials/02-multi-gpu.md
+++ b/docs/tutorials/02-multi-gpu.md
@@ -1,0 +1,58 @@
+# Tutorial 02 — Multi-GPU runs on the MD backends
+
+The swarm is independent across trials, so it spreads across all your GPUs through
+one `ParallelExecutor`. This tutorial shows the config knobs (for real AMBER/
+GROMACS/OpenMM runs) and the in-process API (runnable here).
+
+## In `input.yaml` (real backends)
+
+```yaml
+pathgennie:
+  mode: escape
+  tau1_steps: 5
+  tau2_steps: 10
+  max_trial: 16
+  devices: [0, 1, 2, 3]     # 16 samplers spread across 4 GPUs
+  workers_per_device: 1     # raise for small systems that under-fill a GPU
+  seed: 42
+  max_cycle: 2000
+  save_freq: 2
+  sigma: 0.25
+```
+
+Then:
+
+```bash
+pathgennie-amber   --case my_case/      # or
+pathgennie-gromacs --case my_case/      # or
+pathgennie-openmm  --case my_case/
+```
+
+Each segment exports `CUDA_VISIBLE_DEVICES` for its assigned GPU and writes into
+an isolated `scratch/devN/` directory. `seed` makes the run reproducible.
+
+## In Python (runnable with the toy engine)
+
+Swap `SerialExecutor` for a `ThreadDevicePool`; nothing else changes:
+
+```python
+from pathgennie.core.parallel import ThreadDevicePool
+from pathgennie.core.driver import PathGennieDriver
+
+executor = ThreadDevicePool(devices=[0, 1, 2, 3], workers_per_device=1)
+driver = PathGennieDriver(engine, progress, converged,
+                          executor=executor, sigma=0.2, seed=0)
+# driver.run(...) exactly as in tutorial 01
+```
+
+With one device a `ThreadDevicePool` reproduces `SerialExecutor` for a fixed seed.
+
+## Benchmark the scaling
+
+```bash
+python benchmarks/scaling.py --devices 1 2 4 8 --max-trial 16 --max-cycle 20 --segment-ms 15
+```
+
+This uses a GIL-releasing sleep engine to model a GPU segment and reports
+cycles/second and speedup vs the number of devices. See
+[multi-gpu.md](../multi-gpu.md) for the full discussion.

--- a/docs/tutorials/03-spib-cv.md
+++ b/docs/tutorials/03-spib-cv.md
@@ -1,0 +1,66 @@
+# Tutorial 03 — A learned CV with SPIB
+
+Here we let PathGennie *learn* its progress variable on the fly with SPIB instead
+of hand-crafting one. Requires the `ml` extra: `pip install -e .[ml]` (PyTorch).
+
+## Drive PathGennie with `SPIBProgress`
+
+`SPIBProgress` bootstraps from a coarse geometric CV, buffers the frames the
+driver visits, retrains periodically, then steers using the learned latent.
+
+```python
+import numpy as np
+from pathgennie.core.driver import PathGennieDriver
+from pathgennie.core.parallel import SerialExecutor
+from pathgennie.core.progress import TargetMetric
+from pathgennie.core.toy import ToyLangevinEngine
+from pathgennie.cv.features import Featurizer
+from pathgennie.cv.spib import SPIBProgress
+
+engine = ToyLangevinEngine(dt=0.005)
+initial = engine.create_state((-1.174, 1.477))
+target = np.array([[1.124, -1.485, 0.0]])
+
+xy = lambda c: np.array([c[0, 0], c[0, 1]])
+bootstrap = TargetMetric(xy, target_cv=np.array([1.124, -1.485]))   # coarse CV
+
+progress = SPIBProgress(
+    Featurizer(funcs=[], standardize=False),   # raw coords as features (toy)
+    bootstrap,
+    mode="target", target_coords=target,
+    refresh_every=15, min_frames=30, dt=1,
+    train_kwargs=dict(n_states_init=3, latent_dim=1, epochs=15, n_refine=2, seed=0),
+)
+
+driver = PathGennieDriver(engine, progress, lambda c: False,
+                          executor=SerialExecutor(), sigma=0.2, seed=1, verbosity=0)
+traj, metrics = driver.run(initial, tau1=10, tau2=20, max_trial=6,
+                           max_cycle=50, save_freq=5)
+
+print("SPIB trained:", progress.result is not None)
+print("emergent metastable states:", progress.n_states)
+print("learned CV dim:", progress.project(engine.get_coords(initial)).shape)
+```
+
+The driver calls `progress.observe(coords, cycle)` each cycle (a no-op for static
+CVs) — that's how SPIB accumulates frames and retrains. Once trained, `project`
+returns the learned latent and the driver steers in that space.
+
+## Train SPIB directly on a trajectory
+
+```python
+from pathgennie.cv.spib import train_spib
+result = train_spib(features,           # (n_frames, n_features), time-ordered
+                    dt=1, n_states_init=6, latent_dim=2, epochs=60, seed=0)
+result.labels, result.n_states          # emergent metastable states
+```
+
+## Caveat: trajectory length
+
+A learned CV needs segments long enough to contain real relaxation. In the
+ultrashort `discovery` regime the
+`check_learned_cv_segment_length` guard will warn — prefer the `sampling` profile
+or longer `tau1`/`tau2`. See [strategy-profiles.md](../strategy-profiles.md).
+
+The emergent `state_labels` feed the [roadmap graph](../roadmap-graph.md)
+(tutorial 07).

--- a/docs/tutorials/04-weighted-ensemble.md
+++ b/docs/tutorials/04-weighted-ensemble.md
@@ -1,0 +1,62 @@
+# Tutorial 04 — Free energies & rates with Weighted Ensemble
+
+A discovered path tells you *a* route; Weighted Ensemble (WE) turns it into
+quantitative numbers — a free-energy profile and, with recycling, a rate
+constant. WE runs unbiased MD and resamples weighted walkers, so it reuses the
+same engine and device pool.
+
+## Discover, then run WE
+
+```python
+import numpy as np
+from pathgennie.core.driver import PathGennieDriver
+from pathgennie.core.parallel import SerialExecutor
+from pathgennie.core.progress import EscapeMetric
+from pathgennie.core.toy import ToyLangevinEngine
+from pathgennie.sampling import WeightedEnsembleStage, build_path_ensemble
+
+kT = 2.0
+engine = ToyLangevinEngine(dt=0.005, kT=kT)
+initial = engine.create_state((-1.0, -1.4))
+
+# 1) Discover a path along y, KEEPING restartable seeds (collect_seeds=True).
+y = lambda c: np.array([c[0, 1]])
+progress = EscapeMetric(y, start_cv=np.array([-1.4]), escape_metric="cv0")
+driver = PathGennieDriver(engine, progress, lambda c: False,
+                          executor=SerialExecutor(), sigma=0.3, seed=0, verbosity=0)
+traj, metrics, handles = driver.run(initial, tau1=5, tau2=10, max_trial=6,
+                                    max_cycle=60, save_freq=1, collect_seeds=True)
+ens = build_path_ensemble(traj, metrics, handles=handles, cv_fn=lambda c: c[0, 1])
+
+# 2) Run WE along y.
+stage = WeightedEnsembleStage(cv_fn=lambda c: c[0, 1], tau_steps=10,
+                              n_iterations=400, n_bins=16, target_count=6, seed=1, kT=kT)
+result = stage.run(ens, engine)
+
+centers = result.metadata["bin_centers"]
+for c, f in zip(centers, result.free_energy):
+    print(f"y={c:+.2f}  F={f:.2f}")
+print("total weight (should be 1):", result.weights.sum())
+```
+
+The free-energy minima land in the two Wolfe–Quapp basins (`y ≈ ±1.4`), above the
+central barrier — compare against the analytic marginal with
+`python benchmarks/we_fes.py`.
+
+## Rate constants via recycling
+
+```python
+stage = WeightedEnsembleStage(
+    cv_fn=lambda c: c[0, 1], tau_steps=6, n_iterations=400, n_bins=16,
+    recycle=True, source_cv=-1.4, target_cv=1.2, timestep_ps=0.002, kT=kT,
+)
+result = stage.run(ens, engine)
+print(result.rate_constants)   # {"flux_per_iter": ..., "rate": ...}
+```
+
+## From a real backend
+
+Set `pathgennie.downstream: weighted_ensemble` plus a `weighted_ensemble:` block
+in `input.yaml`; the backend builds the `PathEnsemble` and runs WE automatically,
+writing `free_energy.csv` (+ `rate_constants.json`) — see
+[weighted-ensemble.md](../weighted-ensemble.md).

--- a/docs/tutorials/05-strategy-profiles.md
+++ b/docs/tutorials/05-strategy-profiles.md
@@ -1,0 +1,53 @@
+# Tutorial 05 — Goal-driven strategy profiles
+
+The right settings depend on your *goal*: fast candidate paths want greedy,
+ultrashort, geometric-CV runs; quantitative free energies/kinetics want longer
+segments, a learned CV, and a downstream stage. A `profile` switches the whole
+bundle with one key.
+
+## In `input.yaml`
+
+```yaml
+pathgennie:
+  profile: discovery      # greedy, ultrashort, geometric CV (the original regime)
+  devices: [0, 1]         # explicit keys still override / extend the profile
+```
+
+or
+
+```yaml
+pathgennie:
+  profile: sampling       # longer tau, learned CV, feeds weighted ensemble
+  seed: 7
+```
+
+Profile values fill in only where you did **not** set a key — explicit always
+wins, and omitting `profile` leaves old configs unchanged.
+
+## In Python
+
+```python
+from pathgennie.core.strategy import resolve_profile, get_profile, PROFILES
+
+print(list(PROFILES))                      # ['discovery', 'sampling']
+
+cfg = resolve_profile({"profile": "sampling", "tau1_steps": 30})
+print(cfg["tau1_steps"])   # 30  (explicit wins)
+print(cfg["cv"])           # 'learned'  (from the profile)
+print(cfg["downstream"])   # 'weighted_ensemble'
+
+get_profile("discovery")   # the RunProfile dataclass with all defaults
+```
+
+## The learned-CV guard
+
+If you pick a learned CV but keep ultrashort segments, the guard warns:
+
+```python
+from pathgennie.core.strategy import check_learned_cv_segment_length
+check_learned_cv_segment_length(2, 8, timestep_ps=0.002)    # warns, returns False
+check_learned_cv_segment_length(50, 100, timestep_ps=0.002) # True
+```
+
+See [strategy-profiles.md](../strategy-profiles.md) for the full table of preset
+values.

--- a/docs/tutorials/06-rrt-search.md
+++ b/docs/tutorials/06-rrt-search.md
@@ -1,0 +1,56 @@
+# Tutorial 06 — Non-linear search with RRT-Connect
+
+When the path must move *against* a simple progress metric (backtrack, turn, go
+orthogonal), greedy selection gets stuck. RRT grows a tree in CV space toward
+random targets; RRT-Connect grows two trees and links them. Runnable on the toy
+engine.
+
+## RRT toward a target basin
+
+```python
+import numpy as np
+from pathgennie.core.parallel import SerialExecutor
+from pathgennie.core.toy import ToyLangevinEngine
+from pathgennie.search.rrt import RRT
+
+engine = ToyLangevinEngine(dt=0.005, kT=1.0)
+start = engine.create_state((-1.174, 1.477))           # basin A
+xy = lambda c: np.array([c[0, 0], c[0, 1]])
+
+rrt = RRT(engine, xy, lower=[-2, -2], upper=[2, 2],
+          tau1=5, tau2=10, n_expand=8, sigma=0.05, goal_bias=0.2,
+          executor=SerialExecutor(), seed=0)
+result = rrt.build(start, target_cv=[1.124, -1.485], max_iter=300, goal_tol=0.5)
+
+print("reached target basin:", result.success)
+print("tree size:", result.tree_size)
+print("path length:", len(result.path))
+print("end CV:", result.path[-1].cv)
+```
+
+`result.path` is the list of `Node`s from root to goal; each has `.cv`, `.handle`,
+and `.parent`.
+
+## RRT-Connect (bidirectional)
+
+```python
+from pathgennie.search.rrt import rrt_connect
+
+goal = engine.create_state((1.124, -1.485))            # basin B
+result = rrt_connect(engine, xy, start, goal,
+                     lower=[-2, -2], upper=[2, 2],
+                     tau1=5, tau2=10, n_expand=8, sigma=0.05,
+                     executor=SerialExecutor(), seed=2, max_iter=300, connect_tol=0.6)
+print("linked:", result.success, " joined path length:", len(result.path))
+```
+
+## Tips
+
+- `cv_fn` can be any CV — geometric or the learned SPIB latent. `lower`/`upper`
+  bound the random-target box.
+- Pass a `ThreadDevicePool` as `executor=` to run each expansion's swarm across
+  GPUs.
+- Increase `goal_bias` to pull harder toward the target; raise `n_expand` for a
+  wider swarm per node.
+
+See [non-linear-search.md](../non-linear-search.md) for the algorithm details.

--- a/docs/tutorials/07-roadmap-agent.md
+++ b/docs/tutorials/07-roadmap-agent.md
@@ -1,0 +1,59 @@
+# Tutorial 07 — Metastable states, roadmap & the agent
+
+This ties three pieces together: metastable-state labels (from SPIB or any
+clustering) → a roadmap graph of all-pairs pathways → an agentic controller that
+adapts the swarm. All runnable without MD.
+
+## Build a roadmap from a state-label trajectory
+
+`SPIBProgress.state_labels` gives a per-frame metastable-state id; feed that
+sequence to a `Roadmap`. Here we use a synthetic label trajectory:
+
+```python
+from pathgennie.search.roadmap import Roadmap
+
+rm = Roadmap()
+# e.g. progress.state_labels from a SPIB run; here a synthetic 3-state walk:
+labels = [0, 0, 1, 1, 2, 2, 1, 0, 1, 2, 0, 2]
+rm.observe_sequence(labels)
+
+print("states:", rm.nodes)
+cost, path = rm.min_free_energy_path(0, 2)          # Dijkstra
+print("min-free-energy path 0->2:", path, "cost", round(cost, 3))
+
+for cost, route in rm.k_shortest_paths(0, 2, k=2):   # competing routes (Yen)
+    print("route", route, "cost", round(cost, 3))
+
+report = rm.all_pairs_paths(k=1)                      # every ordered pair
+print("pairs found:", sorted(report))
+```
+
+Edges are weighted by `-log(transition fraction)`, so the cheapest path is the
+maximum-likelihood / minimum-free-energy route.
+
+## Drive the swarm with the agentic controller
+
+```python
+from pathgennie.agent import RuleBasedController, SwarmParams
+
+ctrl = RuleBasedController(SwarmParams(n_trial=8, tau1=4, tau2=8),
+                           stall_window=5, stall_eps=1e-3,
+                           escalate=1.5, relax=0.75, stop_patience=20, refresh_every=50)
+
+metric_history = []
+for cycle in range(200):
+    p = ctrl.update(metric_history)        # adapt N / tau1 / tau2 from progress
+    # ... run one driver cycle with p.n_trial, p.tau1, p.tau2 ...
+    metric_history.append(get_latest_metric())
+    if ctrl.should_refresh_cv(cycle):
+        ...                                # retrain SPIB
+    if ctrl.should_stop(metric_history):
+        break
+```
+
+When progress stalls the controller enlarges the swarm and lengthens the
+segments; when it flows it relaxes the swarm to save compute; on a long plateau it
+recommends stopping. `RuleBasedController.choose_frontier(visit_counts)` picks the
+least-visited region to expand next (anti-trapping for RRT).
+
+See [roadmap-graph.md](../roadmap-graph.md) and [agent.md](../agent.md).

--- a/docs/tutorials/08-opes.md
+++ b/docs/tutorials/08-opes.md
@@ -1,0 +1,62 @@
+# Tutorial 08 — Free-energy surfaces with OPES
+
+OPES deposits an adaptive bias along a CV to flatten sampling and recover a
+free-energy surface. On real systems this runs through **PLUMED**; the algorithm
+core is also runnable here on the toy surface.
+
+## Toy mode (runnable now)
+
+```python
+import numpy as np
+from pathgennie.core.toy import ToyLangevinEngine, wolfe_quapp_gradient
+from pathgennie.sampling import build_path_ensemble
+from pathgennie.sampling.opes import OPESStage
+
+engine = ToyLangevinEngine(dt=0.005, kT=2.0)
+initial = engine.create_state((-1.0, -1.4))
+ens = build_path_ensemble(np.array([engine.get_coords(initial)]), np.array([0.0]),
+                          cv_fn=lambda c: c[0, 1])
+
+stage = OPESStage(
+    mode="toy", potential_grad=wolfe_quapp_gradient, cv_axis=1,
+    grid=np.linspace(-2.0, 2.0, 33), n_steps=20000, pace=20,
+    gamma=15.0, sigma=0.2, barrier=8.0, kT=2.0, seed=0,
+)
+result = stage.run(ens, engine)
+for y, f in zip(result.metadata["grid"], result.free_energy):
+    print(f"y={y:+.2f}  F={f:.2f}")
+```
+
+The recovered `F(y)` matches the analytic Wolfe–Quapp marginal (FES minima in the
+basins, barrier in between).
+
+## PLUMED mode (production)
+
+`OPESStage(mode="plumed")` generates an `OPES_METAD` input and drives a
+PLUMED-capable engine:
+
+```python
+from pathgennie.sampling.opes import build_plumed_opes_input
+
+print(build_plumed_opes_input(
+    ["phi: TORSION ATOMS=5,7,9,15", "psi: TORSION ATOMS=7,9,15,17"],
+    ["phi", "psi"], pace=500, barrier=40.0, temp=300.0, sigma=[0.1, 0.1],
+))
+```
+
+To run it end-to-end the engine must expose `run_plumed(plumed_input, ensemble,
+**cfg)` (a PLUMED-patched MD engine). Without it the stage raises an informative
+`NotImplementedError`. From `input.yaml`:
+
+```yaml
+pathgennie:
+  downstream: opes
+opes:
+  mode: plumed
+  plumed_cv_definitions: ["phi: TORSION ATOMS=5,7,9,15"]
+  plumed_arg_names: ["phi"]
+  pace: 500
+  barrier: 40.0
+```
+
+See [opes.md](../opes.md) for the full reference and the PLUMED integration point.

--- a/docs/tutorials/09-path-sampling.md
+++ b/docs/tutorials/09-path-sampling.md
@@ -1,0 +1,70 @@
+# Tutorial 09 — Kinetics with TPS/TIS (OpenPathSampling)
+
+PathGennie's discovered path is an ideal *seed* for Transition Path Sampling
+(TPS) and Transition Interface Sampling (TIS) — an alternative to Weighted
+Ensemble for kinetics. This tutorial shows the dependency-free seed preparation
+(runnable now) and the OpenPathSampling (OPS) run (needs `pip install -e
+.[pathsampling]` and an OPS engine).
+
+## 1. Discover a path and prepare the OPS seed (runnable now)
+
+```python
+import numpy as np
+from pathgennie.core.driver import PathGennieDriver
+from pathgennie.core.parallel import SerialExecutor
+from pathgennie.core.progress import EscapeMetric
+from pathgennie.core.toy import ToyLangevinEngine
+from pathgennie.sampling import build_path_ensemble
+from pathgennie.sampling.path_sampling import (
+    CVRangeState, extract_transition_path, tis_interfaces, prepare_ops_seed,
+)
+
+engine = ToyLangevinEngine(dt=0.005, kT=1.0)
+initial = engine.create_state((-1.0, -1.4))
+y = lambda c: np.array([c[0, 1]])
+progress = EscapeMetric(y, start_cv=np.array([-1.4]), escape_metric="cv0")
+driver = PathGennieDriver(engine, progress, lambda c: False,
+                          executor=SerialExecutor(), sigma=0.3, seed=0, verbosity=0)
+traj, metrics = driver.run(initial, tau1=5, tau2=10, max_trial=6, max_cycle=80, save_freq=1)
+ens = build_path_ensemble(traj, metrics)
+
+cv = lambda c: c[0, 1]
+A = CVRangeState("A", -2.0, -1.0)
+B = CVRangeState("B",  1.0,  2.0)
+
+print("reactive A->B sub-path:", extract_transition_path(ens.frames, cv, A, B))
+seed = prepare_ops_seed(ens, cv, A, B, interfaces=tis_interfaces(-1.0, 1.0, 6))
+print("reactive:", seed["reactive"], " seed frames:", None if seed["seed_frames"] is None else seed["seed_frames"].shape)
+print("TIS interfaces:", np.round(seed["interfaces"], 2))
+```
+
+(If the run didn't reach basin B, increase `max_cycle` or widen the state ranges.)
+
+## 2. Run TPS / TIS with OpenPathSampling
+
+```python
+import openpathsampling as paths
+from openpathsampling.engines.openmm import Engine as OPSEngine
+from pathgennie.sampling import make_stage
+
+ops_engine = OPSEngine(...)        # build per OPS docs (topology/system/integrator)
+
+# TPS — sample the transition path ensemble
+tps = make_stage("tps", cv_fn=cv, state_a=(-2, -1), state_b=(1, 2),
+                 ops_engine=ops_engine, n_steps=2000, storage_path="tps.nc")
+tps.run(ens, engine=None)
+
+# TIS — rate constant
+tis = make_stage("tis", cv_fn=cv, state_a=(-2, -1), state_b=(1, 2),
+                 interfaces=list(tis_interfaces(-1.0, 1.0, 6)),
+                 ops_engine=ops_engine, n_steps=5000)
+result = tis.run(ens, engine=None)
+print(result.rate_constants)
+```
+
+OPS propagates with **its own** engine (`ops_engine`), not PathGennie's swarm
+engine. Without `openpathsampling` installed the stage raises an informative
+`ImportError`.
+
+See [path-sampling.md](../path-sampling.md) for the full reference and the
+WE-vs-TPS/TIS comparison.

--- a/docs/weighted-ensemble.md
+++ b/docs/weighted-ensemble.md
@@ -1,0 +1,108 @@
+# Weighted Ensemble (free energies & rates)
+
+Weighted Ensemble (WE) keeps a population of trajectories ("walkers"), each
+carrying a statistical *weight*, propagates them with **unbiased** dynamics, and
+periodically *resamples* (splits over-weight walkers, merges under-weight ones)
+so walkers stay spread across bins of a progress coordinate. No bias force is ever
+applied — the weights keep the ensemble unbiased — so WE reuses PathGennie's exact
+`Engine` and `ParallelExecutor` (multi-GPU for free).
+
+PathGennie's stage is **path-informed**: it seeds walkers from a discovered
+`PathEnsemble` and bins along that path's CV range, so WE does not have to first
+find the transition. With recycling it yields a steady-state flux (rate constant);
+the time-averaged bin weights give a free-energy profile along the CV.
+
+## Core pieces (`pathgennie/sampling/weighted_ensemble.py`)
+
+- `Walker(handle, weight, bin, cv)` — a weighted trajectory.
+- `GridBinner` — uniform 1-D bins; `GridBinner.from_values(values, n_bins)` builds
+  edges spanning the path CV range.
+- `resample(walkers, target_count, rng, clone_fn, release_fn)` — Huber–Kim
+  split/merge within one bin, conserving total weight exactly.
+- `WeightedEnsembleStage` — the `SamplingStage` implementation.
+
+## Using it from Python
+
+```python
+from pathgennie.core.driver import PathGennieDriver
+from pathgennie.core.toy import ToyLangevinEngine
+from pathgennie.core.progress import EscapeMetric
+from pathgennie.core.parallel import SerialExecutor
+from pathgennie.sampling import WeightedEnsembleStage, build_path_ensemble
+import numpy as np
+
+engine = ToyLangevinEngine(dt=0.005, kT=2.0)
+initial = engine.create_state((-1.0, -1.4))
+
+# 1) discover a path, retaining restartable seeds
+progress = EscapeMetric(lambda c: np.array([c[0, 1]]), start_cv=np.array([-1.4]), escape_metric="cv0")
+driver = PathGennieDriver(engine, progress, lambda c: False,
+                          executor=SerialExecutor(), sigma=0.3, seed=0, verbosity=0)
+traj, metrics, handles = driver.run(initial, tau1=5, tau2=10, max_trial=6,
+                                    max_cycle=60, save_freq=1, collect_seeds=True)
+ens = build_path_ensemble(traj, metrics, handles=handles, cv_fn=lambda c: c[0, 1])
+
+# 2) run WE along the y coordinate
+stage = WeightedEnsembleStage(cv_fn=lambda c: c[0, 1], tau_steps=10,
+                              n_iterations=400, n_bins=16, target_count=6, seed=1, kT=2.0)
+result = stage.run(ens, engine)
+
+result.free_energy            # F over result.metadata["bin_centers"]
+result.weights                # final walker weights (sum to 1)
+result.metadata["weight_trace"]  # total weight per iteration (== 1)
+```
+
+### Rate constants (recycling)
+
+Set `recycle=True` with a `source_cv` and `target_cv`; walkers crossing the
+target add their weight to the flux and are re-injected at the source:
+
+```python
+stage = WeightedEnsembleStage(
+    cv_fn=lambda c: c[0, 1], tau_steps=6, n_iterations=400, n_bins=16,
+    recycle=True, source_cv=-1.4, target_cv=1.2, timestep_ps=0.002, kT=2.0,
+)
+result = stage.run(ens, engine)
+result.rate_constants   # {"flux_per_iter": ..., "rate": ...}
+```
+
+`rate` uses `tau_steps * timestep_ps` when `timestep_ps` is given, else
+per-iteration units.
+
+## Multi-GPU
+
+Pass a `ThreadDevicePool` as `executor=` to spread the per-iteration walker
+segments across GPUs — exactly as for discovery.
+
+## From `input.yaml` (backends)
+
+When `pathgennie.downstream: weighted_ensemble` is set, the backend `run()` builds
+the `PathEnsemble` (via `collect_seeds`) and runs WE automatically, writing
+`free_energy.csv` (and `rate_constants.json` if recycling) into the output
+directory:
+
+```yaml
+pathgennie:
+  downstream: weighted_ensemble
+  # ... discovery settings ...
+weighted_ensemble:
+  cv_component: 0        # which projection component to bin along
+  tau_steps: 1000
+  n_iterations: 200
+  n_bins: 20
+  target_count: 5
+  recycle: false
+```
+
+> The real-MD backend path is wired through the same `run_downstream` helper that
+> the toy tests cover, but cannot be executed in a CPU-only sandbox. See
+> [roadmap.md](roadmap.md).
+
+## Validation
+
+`benchmarks/we_fes.py` compares the WE profile `F(y)` to the analytic Wolfe–Quapp
+marginal:
+
+```bash
+python benchmarks/we_fes.py
+```

--- a/pathgennie/__init__.py
+++ b/pathgennie/__init__.py
@@ -1,3 +1,3 @@
 """PathGennie package."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/pathgennie/agent/__init__.py
+++ b/pathgennie/agent/__init__.py
@@ -1,0 +1,13 @@
+"""Agentic orchestration for PathGennie.
+
+The controller automates the "how hard to throw the swarm" decisions that are
+otherwise hand-tuned: the swarm size ``N`` and segment lengths ``tau1``/``tau2``,
+when to expand an under-explored frontier, when to refresh a learned CV, and when
+to stop.  :class:`RuleBasedController` is a deterministic, testable policy (the
+plan's "rule-based first"); it implements the same ``Controller`` surface a future
+RL or LLM meta-controller would, so it can be swapped without touching the driver.
+"""
+
+from .controller import Controller, RuleBasedController, SwarmParams
+
+__all__ = ["Controller", "RuleBasedController", "SwarmParams"]

--- a/pathgennie/agent/controller.py
+++ b/pathgennie/agent/controller.py
@@ -1,0 +1,127 @@
+"""Rule-based adaptive controller for the PathGennie swarm.
+
+Each round the controller looks at the recent progress history and adjusts the
+sampling effort:
+
+* **stalling** (progress rate below a threshold) → *escalate*: enlarge the swarm
+  ``N`` and lengthen the sampler segment ``tau1`` (and ``tau2``) so the search
+  pushes harder over the barrier;
+* **progressing well** → *relax*: shrink ``N`` back toward its minimum to save GPU
+  time (progress-per-wall-second, not raw progress, is the objective);
+* **plateaued** for a long time → recommend stopping.
+
+It also offers count-based frontier selection (expand the least-visited region —
+anti-trapping) and a CV-refresh schedule (for SPIB).  Everything is deterministic
+given its inputs, so it is unit-testable; the same surface (``Controller``) could
+later be backed by a contextual-bandit/RL agent or an LLM meta-controller.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional, Protocol, Sequence
+
+import numpy as np
+
+__all__ = ["SwarmParams", "Controller", "RuleBasedController"]
+
+
+@dataclass
+class SwarmParams:
+    n_trial: int
+    tau1: int
+    tau2: int
+
+
+class Controller(Protocol):
+    def update(self, metric_history: Sequence[float]) -> SwarmParams: ...
+    def should_stop(self, metric_history: Sequence[float]) -> bool: ...
+
+
+class RuleBasedController:
+    def __init__(
+        self,
+        params: SwarmParams,
+        *,
+        n_bounds: tuple = (4, 64),
+        tau1_bounds: tuple = (2, 200),
+        tau2_bounds: tuple = (4, 400),
+        stall_window: int = 5,
+        stall_eps: float = 1e-3,
+        escalate: float = 1.5,
+        relax: float = 0.75,
+        stop_patience: int = 20,
+        refresh_every: int = 50,
+    ):
+        self.params = SwarmParams(int(params.n_trial), int(params.tau1), int(params.tau2))
+        self.n_bounds = n_bounds
+        self.tau1_bounds = tau1_bounds
+        self.tau2_bounds = tau2_bounds
+        self.stall_window = int(stall_window)
+        self.stall_eps = float(stall_eps)
+        self.escalate = float(escalate)
+        self.relax = float(relax)
+        self.stop_patience = int(stop_patience)
+        self.refresh_every = int(refresh_every)
+        self._best = -np.inf
+        self._since_improve = 0
+        self._last_refresh = -self.refresh_every
+
+    # -- progress bookkeeping ------------------------------------------------
+    def _progress_rate(self, metric_history: Sequence[float]) -> Optional[float]:
+        if len(metric_history) < 2:
+            return None
+        window = list(metric_history)[-self.stall_window:]
+        if len(window) < 2:
+            return None
+        return (window[-1] - window[0]) / (len(window) - 1)
+
+    def _note_improvement(self, metric_history: Sequence[float]) -> None:
+        if not metric_history:
+            return
+        latest = float(metric_history[-1])
+        if latest > self._best + self.stall_eps:
+            self._best = latest
+            self._since_improve = 0
+        else:
+            self._since_improve += 1
+
+    # -- public API ----------------------------------------------------------
+    def update(self, metric_history: Sequence[float]) -> SwarmParams:
+        """Return adjusted swarm parameters given the progress history."""
+        self._note_improvement(metric_history)
+        rate = self._progress_rate(metric_history)
+        if rate is None:
+            return self.params
+
+        n_lo, n_hi = self.n_bounds
+        t1_lo, t1_hi = self.tau1_bounds
+        t2_lo, t2_hi = self.tau2_bounds
+        if rate < self.stall_eps:
+            # Stalling: push harder.
+            self.params.n_trial = int(min(n_hi, max(n_lo, round(self.params.n_trial * self.escalate))))
+            self.params.tau1 = int(min(t1_hi, max(t1_lo, round(self.params.tau1 * self.escalate))))
+            self.params.tau2 = int(min(t2_hi, max(t2_lo, round(self.params.tau2 * self.escalate))))
+        else:
+            # Progressing: relax the swarm size to save compute.
+            self.params.n_trial = int(min(n_hi, max(n_lo, round(self.params.n_trial * self.relax))))
+        return self.params
+
+    def should_stop(self, metric_history: Sequence[float]) -> bool:
+        """Recommend stopping once progress has plateaued for ``stop_patience``."""
+        return self._since_improve >= self.stop_patience
+
+    def should_refresh_cv(self, cycle: int) -> bool:
+        """True on a refresh-schedule boundary (drives SPIB retraining)."""
+        if cycle - self._last_refresh >= self.refresh_every:
+            self._last_refresh = cycle
+            return True
+        return False
+
+    @staticmethod
+    def choose_frontier(visit_counts: Sequence[int]) -> int:
+        """Pick the least-visited node (count-based novelty / anti-trapping)."""
+        counts = np.asarray(visit_counts, dtype=float)
+        if counts.size == 0:
+            raise ValueError("visit_counts must be non-empty")
+        return int(counts.argmin())

--- a/pathgennie/backends/amber/__init__.py
+++ b/pathgennie/backends/amber/__init__.py
@@ -2,15 +2,20 @@
 
 from typing import TYPE_CHECKING
 
-__all__ = ["GenericAmberEngine", "GenericPathGennieAmber", "run"]
+__all__ = ["CoreAmberEngine", "run"]
 
 if TYPE_CHECKING:
-    from .pg_amber import GenericAmberEngine, GenericPathGennieAmber, run
+    from .engine import CoreAmberEngine
+    from .pg_amber import run
 
 
 def __getattr__(name: str):
-    if name in __all__:
+    if name == "CoreAmberEngine":
+        from .engine import CoreAmberEngine
+
+        return CoreAmberEngine
+    if name == "run":
         from . import pg_amber
 
-        return getattr(pg_amber, name)
+        return pg_amber.run
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/pathgennie/backends/amber/engine.py
+++ b/pathgennie/backends/amber/engine.py
@@ -1,0 +1,133 @@
+"""Device-aware AMBER engine adapter for the PathGennie core driver.
+
+Implements the :class:`pathgennie.core.engine.Engine` protocol by shelling out to
+``pmemd.cuda``/``sander`` per segment.  Two problems in the original
+``GenericPathGennieAmber`` are fixed here:
+
+* **No multi-GPU:** the old ``ThreadPoolExecutor`` launched every worker with the
+  inherited environment, so all trials landed on GPU 0.  ``run_segment`` now sets
+  ``CUDA_VISIBLE_DEVICES`` to the device the executor assigned, so a swarm spreads
+  across all GPUs (``subprocess.run`` releases the GIL, so threads genuinely run
+  concurrently).
+* **Scratch races:** trials wrote files with colliding names into one directory.
+  Each segment now gets a unique, per-device scratch subdirectory and a unique
+  file stem.
+
+A *handle* is an absolute path to an AMBER restart (``rst7``) file.
+"""
+
+from __future__ import annotations
+
+import itertools
+import os
+import subprocess
+import threading
+import uuid
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+
+from .utils import read_rst7_coords, write_mdin
+
+__all__ = ["CoreAmberEngine"]
+
+
+class CoreAmberEngine:
+    def __init__(
+        self,
+        *,
+        topology: Path,
+        executable: Path,
+        scratch_dir: Path,
+        temperature: float,
+        mdin_controls: dict,
+        extra_mdin_text: str = "",
+        command_prefix: Optional[list] = None,
+    ):
+        self.topology = str(topology)
+        self.exe = str(executable)
+        self.scratch_dir = Path(scratch_dir)
+        self.scratch_dir.mkdir(parents=True, exist_ok=True)
+        self.temperature = float(temperature)
+        self.mdin_controls = mdin_controls
+        self.extra_mdin_text = extra_mdin_text
+        self.command_prefix = command_prefix or []
+        self._counter = itertools.count()
+        self._lock = threading.Lock()
+
+    def _uid(self) -> str:
+        with self._lock:
+            n = next(self._counter)
+        return f"{n}_{uuid.uuid4().hex[:8]}"
+
+    def _device_dir(self, device: Optional[int]) -> Path:
+        name = "dev_cpu" if device is None else f"dev{device}"
+        path = self.scratch_dir / name
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def clone_anchor(self, handle):
+        src = Path(handle)
+        dst = self.scratch_dir / f"anchor_{self._uid()}.rst7"
+        dst.write_bytes(src.read_bytes())
+        return str(dst)
+
+    def run_segment(self, handle, n_steps, *, randomize_velocities, seed, device=None):
+        workdir = self._device_dir(device)
+        stem = f"seg_{self._uid()}"
+        mdin = workdir / f"{stem}.mdin"
+        out_rst = workdir / f"{stem}.rst7"
+        write_mdin(
+            mdin,
+            int(n_steps),
+            self.temperature,
+            self.mdin_controls,
+            continue_velocities=not randomize_velocities,
+            random_seed=int(seed),
+            extra_text=self.extra_mdin_text,
+        )
+        cmd = [
+            *self.command_prefix, self.exe, "-O",
+            "-i", str(mdin),
+            "-p", self.topology,
+            "-c", str(handle),
+            "-r", str(out_rst),
+            "-o", str(workdir / f"{stem}.out"),
+            "-inf", str(workdir / f"{stem}.mdinfo"),
+        ]
+        if self.mdin_controls.get("ntwx", 0):
+            cmd.extend(["-x", str(workdir / f"{stem}.nc")])
+
+        env = os.environ.copy()
+        if device is not None:
+            env["CUDA_VISIBLE_DEVICES"] = str(device)
+
+        try:
+            subprocess.run(cmd, check=True, capture_output=True, text=True, env=env)
+        except subprocess.CalledProcessError as exc:
+            message = [
+                f"AMBER segment failed with exit code {exc.returncode}.",
+                "Command: " + " ".join(cmd),
+            ]
+            if exc.stdout:
+                message.append("stdout:\n" + exc.stdout[-4000:])
+            if exc.stderr:
+                message.append("stderr:\n" + exc.stderr[-4000:])
+            raise RuntimeError("\n".join(message)) from exc
+        return str(out_rst)
+
+    def get_coords(self, handle):
+        coords = read_rst7_coords(handle)
+        if not np.all(np.isfinite(coords)):
+            raise ValueError(f"AMBER segment produced non-finite coordinates: {handle}")
+        return coords
+
+    def release(self, handle):
+        path = Path(handle)
+        stem = path.with_suffix("")
+        for sibling in path.parent.glob(stem.name + ".*"):
+            try:
+                sibling.unlink()
+            except OSError:
+                pass

--- a/pathgennie/backends/amber/pg_amber.py
+++ b/pathgennie/backends/amber/pg_amber.py
@@ -134,14 +134,21 @@ def run(case_dir: Path, config_name: str = "input.yaml") -> None:
         verbosity=pg_cfg.get("verbosity", 1),
     )
 
-    traj, metrics = driver.run(
+    downstream = pg_cfg.get("downstream")
+    result = driver.run(
         str(initial_restart),
         tau1=pg_cfg["tau1_steps"],
         tau2=pg_cfg["tau2_steps"],
         max_trial=pg_cfg["max_trial"],
         max_cycle=pg_cfg["max_cycle"],
         save_freq=pg_cfg.get("save_freq", 10),
+        collect_seeds=bool(downstream),
     )
+    seed_handles = None
+    if downstream:
+        traj, metrics, seed_handles = result
+    else:
+        traj, metrics = result
 
     trajectory_path = output_dir / cfg.get("output", {}).get("trajectory", "reactive_path.pdb")
     metrics_path = output_dir / cfg.get("output", {}).get("metrics", "metrics.csv")
@@ -149,6 +156,18 @@ def run(case_dir: Path, config_name: str = "input.yaml") -> None:
         traj = wrap_frames_pbc(traj, topology_info)
     write_trajectory(trajectory_path, topology_info, traj)
     write_metrics_csv(metrics_path, metrics)
+
+    # Optional downstream enhanced-sampling stage (uses scratch, so before cleanup).
+    if downstream:
+        from pathgennie.sampling.runner import make_scalar_cv, run_downstream
+        stage_cfg = dict(cfg.get(downstream, {}))
+        component = stage_cfg.pop("cv_component", 0)
+        scalar_cv = make_scalar_cv(proj_fn, projection_args, component)
+        run_downstream(
+            downstream, stage_cfg, engine=engine, traj=traj, metrics=metrics,
+            seed_handles=seed_handles, scalar_cv_fn=scalar_cv, output_dir=output_dir,
+        )
+
     shutil.rmtree(scratch_dir)
 
     print(f"Saved frames: {len(traj)}")

--- a/pathgennie/backends/amber/pg_amber.py
+++ b/pathgennie/backends/amber/pg_amber.py
@@ -1,27 +1,27 @@
 #!/usr/bin/env python
-"""Generic PathGennie Amber runner driven by a case-local input.yaml."""
+"""Generic PathGennie Amber runner driven by a case-local input.yaml.
+
+The adaptive cycle now lives in :mod:`pathgennie.core`; this module only loads
+the case configuration, builds a device-aware :class:`CoreAmberEngine`, and runs
+the shared :class:`~pathgennie.core.driver.PathGennieDriver` over a device pool so
+the swarm spreads across all configured GPUs.
+"""
 
 from __future__ import annotations
 
 import argparse
 import os
-import random
 import shutil
-import subprocess
-from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import numpy as np
 import yaml
 
-try:
-    from tqdm.auto import trange  # type: ignore
-except ModuleNotFoundError:
+from pathgennie.core.driver import PathGennieDriver
+from pathgennie.core.parallel import ThreadDevicePool
+from pathgennie.core.progress import EscapeMetric, TargetMetric
 
-    def trange(*args, **kwargs):
-        return range(*args)
-
-
+from .engine import CoreAmberEngine
 from .utils import (
     default_mdin_controls,
     enrich_args,
@@ -30,216 +30,9 @@ from .utils import (
     read_rst7_coords,
     resolve_case_path,
     wrap_frames_pbc,
-    write_mdin,
     write_metrics_csv,
     write_trajectory,
 )
-
-RNG = random.SystemRandom()
-
-
-class GenericAmberEngine:
-    def __init__(
-        self,
-        *,
-        topology: Path,
-        executable: Path,
-        scratch_dir: Path,
-        tau1_steps: int,
-        tau2_steps: int,
-        temperature: float,
-        mdin_controls: dict[str, object],
-        extra_mdin_text: str = "",
-        command_prefix: list[str] | None = None,
-    ):
-        self.topology = str(topology)
-        self.exe = str(executable)
-        self.scratch_dir = scratch_dir
-        self.scratch_dir.mkdir(parents=True, exist_ok=True)
-        self.tau1_steps = int(tau1_steps)
-        self.tau2_steps = int(tau2_steps)
-        self.temperature = float(temperature)
-        self.mdin_controls = mdin_controls
-        self.extra_mdin_text = extra_mdin_text
-        self.command_prefix = command_prefix or []
-
-    def state_path(self, path: str | Path) -> Path:
-        path = Path(path)
-        if path.is_absolute():
-            return path
-        scratch_path = self.scratch_dir / path
-        if scratch_path.exists():
-            return scratch_path
-        if path.exists():
-            return path
-        return scratch_path
-
-    def copy_state(self, src, dst):
-        dst_path = Path(dst)
-        if not dst_path.is_absolute():
-            dst_path = self.scratch_dir / dst_path
-        shutil.copy(self.state_path(src), dst_path)
-
-    def run_segment(self, input_rst, output_prefix):
-        output_name = Path(output_prefix).name
-        is_tau2 = output_name.startswith("tau2_")
-        output_prefix = self.scratch_dir / output_name
-        out_rst = output_prefix.with_suffix(".rst7")
-        mdin = self.scratch_dir / f"{output_name}.mdin"
-        write_mdin(
-            mdin,
-            self.tau2_steps if is_tau2 else self.tau1_steps,
-            self.temperature,
-            self.mdin_controls,
-            continue_velocities=is_tau2,
-            random_seed=RNG.randint(1, 2_000_000_000),
-            extra_text=self.extra_mdin_text,
-        )
-
-        cmd = [
-            *self.command_prefix,
-            self.exe,
-            "-O",
-            "-i",
-            str(mdin),
-            "-p",
-            self.topology,
-            "-c",
-            str(self.state_path(input_rst)),
-            "-r",
-            str(out_rst),
-            "-o",
-            str(output_prefix.with_suffix(".out")),
-            "-inf",
-            str(output_prefix.with_suffix(".mdinfo")),
-        ]
-        if self.mdin_controls.get("ntwx", 0):
-            cmd.extend(["-x", str(output_prefix.with_suffix(".nc"))])
-        subprocess.run(cmd, check=True, capture_output=True, text=True)
-        return str(out_rst)
-
-    def load_coords(self, rst):
-        return read_rst7_coords(self.state_path(rst))
-
-
-class GenericPathGennieAmber:
-    def __init__(
-        self,
-        *,
-        engine,
-        projection_fn,
-        convergence_fn,
-        sigma=0.1,
-        mode="escape",
-        target_projection=None,
-        projection_args=None,
-        convergence_args=None,
-        tau1_workers=1,
-        escape_metric="cv0",
-        reject_worse_tau2=False,
-        reject_worse_anchor=False,
-    ):
-        self.engine = engine
-        self.proj_fn = projection_fn
-        self.conv_fn = convergence_fn
-        self.mode = mode
-        self.sigma = sigma
-        self.target = target_projection
-        self.proj_args = projection_args or {}
-        self.conv_args = convergence_args or {}
-        self.tau1_workers = max(1, int(tau1_workers))
-        self.escape_metric = escape_metric
-        self.reject_worse_tau2 = bool(reject_worse_tau2)
-        self.reject_worse_anchor = bool(reject_worse_anchor)
-
-    def metric(self, cv, start_proj):
-        if self.mode == "escape":
-            if self.escape_metric == "distance_from_start":
-                return np.linalg.norm(cv - start_proj)
-            return float(cv[0])
-        return -np.linalg.norm(cv - self.target)
-
-    def run(self, initial_restart, max_trial=20, max_cycle=1000, save_freq=10):
-        anchor_rst = "anchor.rst7"
-        self.engine.copy_state(initial_restart, anchor_rst)
-        start_pos = self.engine.load_coords(anchor_rst)
-        start_proj = self.proj_fn(start_pos, **self.proj_args)
-        anchor_pos = start_pos
-        anchor_cv = start_proj
-        anchor_metric = self.metric(anchor_cv, start_proj)
-
-        trajectory = []
-        metric_history = []
-
-        def run_trial(cycle, trial):
-            trial_input = f"trial_{trial}.rst7"
-            self.engine.copy_state(anchor_rst, trial_input)
-            tau1_rst = self.engine.run_segment(trial_input, f"tau1_{cycle}_{trial}")
-            pos = self.engine.load_coords(tau1_rst)
-            cv = self.proj_fn(pos, **self.proj_args)
-            return {"rst": tau1_rst, "metric": self.metric(cv, start_proj), "cv": cv}
-
-        for cycle in trange(max_cycle):
-            previous_anchor_rst = anchor_rst
-            workers = min(self.tau1_workers, max_trial)
-            if workers == 1:
-                trials = [run_trial(cycle, trial) for trial in range(max_trial)]
-            else:
-                with ThreadPoolExecutor(max_workers=workers) as executor:
-                    trials = list(executor.map(lambda trial: run_trial(cycle, trial), range(max_trial)))
-
-            metrics = np.array([trial["metric"] for trial in trials])
-            mmin = metrics.min()
-            mmax = metrics.max()
-            if abs(mmax - mmin) < 1e-12:
-                probs = np.ones(len(metrics)) / len(metrics)
-            else:
-                scaled = (metrics - mmin) / (mmax - mmin)
-                weights = np.exp((scaled - 1.0) / self.sigma)
-                probs = weights / weights.sum()
-
-            chosen = trials[np.random.choice(len(trials), p=probs)]
-            tau2_rst = self.engine.run_segment(chosen["rst"], f"tau2_{cycle}")
-            tau2_pos = self.engine.load_coords(tau2_rst)
-            tau2_cv = self.proj_fn(tau2_pos, **self.proj_args)
-            tau2_metric = self.metric(tau2_cv, start_proj)
-
-            if self.reject_worse_tau2 and tau2_metric < chosen["metric"]:
-                anchor_rst = chosen["rst"]
-                pos = self.engine.load_coords(anchor_rst)
-                cv = chosen["cv"]
-                metric = chosen["metric"]
-                print(f"Cycle {cycle}: rejected tau2 metric={tau2_metric:.4f}; kept tau1 metric={metric:.4f}, CV={cv}")
-            else:
-                anchor_rst = tau2_rst
-                pos = tau2_pos
-                cv = tau2_cv
-                metric = tau2_metric
-
-            if self.reject_worse_anchor and metric < anchor_metric:
-                print(
-                    f"Cycle {cycle}: rejected candidate metric={metric:.4f}; "
-                    f"kept anchor metric={anchor_metric:.4f}, CV={anchor_cv}"
-                )
-                anchor_rst = previous_anchor_rst
-                pos = anchor_pos
-                cv = anchor_cv
-                metric = anchor_metric
-            else:
-                anchor_pos = pos
-                anchor_cv = cv
-                anchor_metric = metric
-            metric_history.append(metric)
-
-            if cycle % save_freq == 0:
-                print(f"Cycle {cycle}: metric={metric:.4f}, CV={cv}")
-                trajectory.append(pos.copy())
-
-            if self.conv_fn(pos, **self.conv_args):
-                print(f"Converged at cycle {cycle}")
-                break
-
-        return np.asarray(trajectory), np.asarray(metric_history)
 
 
 def run(case_dir: Path, config_name: str = "input.yaml") -> None:
@@ -284,26 +77,6 @@ def run(case_dir: Path, config_name: str = "input.yaml") -> None:
             *[str(arg) for arg in amber_cfg.get("mpi_launcher_args", [])],
         ]
 
-    write_mdin(
-        workdir / "tau1.mdin",
-        pg_cfg["tau1_steps"],
-        temperature,
-        mdin_controls,
-        continue_velocities=False,
-        random_seed=-1,
-        extra_text=extra_mdin_text,
-    )
-    write_mdin(
-        workdir / "tau2.mdin",
-        pg_cfg["tau2_steps"],
-        temperature,
-        mdin_controls,
-        continue_velocities=True,
-        random_seed=-1,
-        extra_text=extra_mdin_text,
-    )
-    print(f"Using generated Amber mdin files: {workdir / 'tau1.mdin'} and {workdir / 'tau2.mdin'}")
-
     proj_fn = load_function(case_dir, cfg["projection"]["module"], cfg["projection"]["function"])
     conv_fn = load_function(case_dir, cfg["convergence"]["module"], cfg["convergence"]["function"])
 
@@ -316,46 +89,54 @@ def run(case_dir: Path, config_name: str = "input.yaml") -> None:
     projection_args = enrich_args(projection_args, topology_info)
     convergence_args = enrich_args(convergence_args, topology_info)
 
-    initial_cv = proj_fn(read_rst7_coords(initial_restart), **projection_args)
-    print(f"Initial CV: {initial_cv}")
+    start_coords = read_rst7_coords(initial_restart)
+    start_cv = np.asarray(proj_fn(start_coords, **projection_args), dtype=float)
+    print(f"Initial CV: {start_cv}")
 
     mode = pg_cfg.get("mode", "escape")
-    target_projection = None
     if mode == "target":
         if "target_projection" not in pg_cfg:
             raise ValueError("pathgennie.mode is 'target', but pathgennie.target_projection is missing")
-        target_projection = np.asarray(pg_cfg["target_projection"], dtype=float)
-        if target_projection.ndim == 0:
-            target_projection = target_projection.reshape(1)
+        target_projection = np.asarray(pg_cfg["target_projection"], dtype=float).reshape(-1)
+        progress = TargetMetric(proj_fn, target_projection, projection_args=projection_args)
+    else:
+        progress = EscapeMetric(
+            proj_fn, start_cv, projection_args=projection_args,
+            escape_metric=pg_cfg.get("escape_metric", "cv0"),
+        )
 
-    engine = GenericAmberEngine(
+    def convergence(coords: np.ndarray) -> bool:
+        return bool(conv_fn(coords, **convergence_args))
+
+    engine = CoreAmberEngine(
         topology=topology,
         executable=executable,
         scratch_dir=scratch_dir,
-        tau1_steps=pg_cfg["tau1_steps"],
-        tau2_steps=pg_cfg["tau2_steps"],
         temperature=temperature,
         mdin_controls=mdin_controls,
         extra_mdin_text=extra_mdin_text,
         command_prefix=command_prefix,
     )
-    runner = GenericPathGennieAmber(
-        engine=engine,
-        projection_fn=proj_fn,
-        convergence_fn=conv_fn,
+
+    # Device pool: `devices` lists GPU indices; falls back to legacy tau1_workers.
+    devices = pg_cfg.get("devices", amber_cfg.get("devices"))
+    workers_per_device = int(pg_cfg.get("workers_per_device", pg_cfg.get("tau1_workers", 1)))
+    executor = ThreadDevicePool(devices=devices, workers_per_device=workers_per_device)
+
+    driver = PathGennieDriver(
+        engine, progress, convergence,
+        executor=executor,
         sigma=pg_cfg["sigma"],
-        mode=mode,
-        target_projection=target_projection,
-        projection_args=projection_args,
-        convergence_args=convergence_args,
-        tau1_workers=pg_cfg.get("tau1_workers", 1),
-        escape_metric=pg_cfg.get("escape_metric", "cv0"),
+        seed=pg_cfg.get("seed"),
         reject_worse_tau2=pg_cfg.get("reject_worse_tau2", False),
         reject_worse_anchor=pg_cfg.get("reject_worse_anchor", False),
+        verbosity=pg_cfg.get("verbosity", 1),
     )
 
-    traj, metrics = runner.run(
-        initial_restart=str(initial_restart),
+    traj, metrics = driver.run(
+        str(initial_restart),
+        tau1=pg_cfg["tau1_steps"],
+        tau2=pg_cfg["tau2_steps"],
         max_trial=pg_cfg["max_trial"],
         max_cycle=pg_cfg["max_cycle"],
         save_freq=pg_cfg.get("save_freq", 10),

--- a/pathgennie/backends/amber/pg_amber.py
+++ b/pathgennie/backends/amber/pg_amber.py
@@ -20,6 +20,7 @@ import yaml
 from pathgennie.core.driver import PathGennieDriver
 from pathgennie.core.parallel import ThreadDevicePool
 from pathgennie.core.progress import EscapeMetric, TargetMetric
+from pathgennie.core.strategy import resolve_profile
 
 from .engine import CoreAmberEngine
 from .utils import (
@@ -49,7 +50,7 @@ def run(case_dir: Path, config_name: str = "input.yaml") -> None:
     output_dir.mkdir(parents=True, exist_ok=True)
 
     amber_cfg = cfg["amber"]
-    pg_cfg = cfg["pathgennie"]
+    pg_cfg = resolve_profile(cfg["pathgennie"])
     topology = resolve_case_path(case_dir, amber_cfg["topology"])
     initial_restart = resolve_case_path(case_dir, amber_cfg["initial_restart"])
     executable = Path(amber_cfg["executable"]).expanduser()

--- a/pathgennie/backends/gromacs/__init__.py
+++ b/pathgennie/backends/gromacs/__init__.py
@@ -2,10 +2,10 @@
 
 from typing import TYPE_CHECKING
 
-__all__ = ["GenericGromacsEngine", "GenericPathGennieGromacs", "run"]
+__all__ = ["CoreGromacsEngine", "run"]
 
 if TYPE_CHECKING:
-    from .pg_gmx import GenericGromacsEngine, GenericPathGennieGromacs, run
+    from .pg_gmx import CoreGromacsEngine, run
 
 
 def __getattr__(name: str):

--- a/pathgennie/backends/gromacs/pg_gmx.py
+++ b/pathgennie/backends/gromacs/pg_gmx.py
@@ -1,26 +1,32 @@
 #!/usr/bin/env python
-"""Generic PathGennie GROMACS runner driven by a case-local input.yaml."""
+"""Generic PathGennie GROMACS runner driven by a case-local input.yaml.
+
+The adaptive cycle lives in :mod:`pathgennie.core`; this module loads the case
+configuration, builds a device-aware :class:`CoreGromacsEngine`, and runs the
+shared :class:`~pathgennie.core.driver.PathGennieDriver` over a device pool so the
+swarm spreads across all configured GPUs (each segment exports
+``CUDA_VISIBLE_DEVICES`` for its assigned device and uses an isolated scratch
+subdirectory).
+"""
 
 from __future__ import annotations
 
 import argparse
+import itertools
 import os
 import random
 import shutil
 import subprocess
-from concurrent.futures import ThreadPoolExecutor
+import threading
+import uuid
 from pathlib import Path
 
 import numpy as np
 import yaml
 
-try:
-    from tqdm.auto import trange  # type: ignore
-except ModuleNotFoundError:
-
-    def trange(*args, **kwargs):
-        return range(*args)
-
+from pathgennie.core.driver import PathGennieDriver
+from pathgennie.core.parallel import ThreadDevicePool
+from pathgennie.core.progress import EscapeMetric, TargetMetric
 
 from .utils import (
     enrich_args,
@@ -35,23 +41,8 @@ from .utils import (
 RNG = random.SystemRandom()
 
 IGNORED_AMBER_MDP_KEYS = {
-    "cut",
-    "gamma-ln",
-    "igb",
-    "imin",
-    "ioutfm",
-    "irest",
-    "ntb",
-    "ntc",
-    "ntf",
-    "ntp",
-    "ntpr",
-    "ntwx",
-    "ntwr",
-    "ntx",
-    "ntxo",
-    "temp0",
-    "tempi",
+    "cut", "gamma-ln", "igb", "imin", "ioutfm", "irest", "ntb", "ntc", "ntf",
+    "ntp", "ntpr", "ntwx", "ntwr", "ntx", "ntxo", "temp0", "tempi",
 }
 
 
@@ -138,21 +129,19 @@ def split_grompp_only_args(
     return grompp_args, remaining_mdrun_args
 
 
-class GromacsState:
-    def __init__(self, gro: Path, cpt: Path | None = None):
-        self.gro = gro
-        self.cpt = cpt if cpt is not None and cpt.exists() else None
+class CoreGromacsEngine:
+    """Device-aware GROMACS engine implementing the core Engine protocol.
 
+    A *handle* is the path to a ``.gro`` structure; the matching checkpoint is the
+    sibling ``.cpt`` (carried so tau2 runners can continue velocities).
+    """
 
-class GenericGromacsEngine:
     def __init__(
         self,
         *,
         topology: Path,
         executable: Path,
         scratch_dir: Path,
-        tau1_steps: int,
-        tau2_steps: int,
         temperature: float,
         mdp_controls: dict[str, object],
         maxwarn: int = 1,
@@ -161,112 +150,90 @@ class GenericGromacsEngine:
     ):
         self.topology = str(topology)
         self.exe = str(executable)
-        self.scratch_dir = scratch_dir
+        self.scratch_dir = Path(scratch_dir)
         self.scratch_dir.mkdir(parents=True, exist_ok=True)
-        self.tau1_steps = int(tau1_steps)
-        self.tau2_steps = int(tau2_steps)
         self.temperature = float(temperature)
         self.mdp_controls = mdp_controls
         self.maxwarn = int(maxwarn)
         self.grompp_args = grompp_args or []
         self.mdrun_args = mdrun_args or []
+        self._counter = itertools.count()
+        self._lock = threading.Lock()
 
-    def state_path(self, path: str | Path) -> Path:
-        path = Path(path)
-        if path.is_absolute():
-            return path
-        scratch_path = self.scratch_dir / path
-        if scratch_path.exists():
-            return scratch_path
-        if path.exists():
-            return path
-        return scratch_path
+    def _uid(self) -> str:
+        with self._lock:
+            n = next(self._counter)
+        return f"{n}_{uuid.uuid4().hex[:8]}"
 
-    def state(self, value: str | Path | GromacsState) -> GromacsState:
-        if isinstance(value, GromacsState):
-            return value
-        gro = self.state_path(value)
-        cpt = gro.with_suffix(".cpt")
-        return GromacsState(gro=gro, cpt=cpt if cpt.exists() else None)
+    def _device_dir(self, device):
+        name = "dev_cpu" if device is None else f"dev{device}"
+        path = self.scratch_dir / name
+        path.mkdir(parents=True, exist_ok=True)
+        return path
 
-    def copy_state(self, src, dst):
-        src_state = self.state(src)
-        dst_path = Path(dst)
-        if dst_path.suffix != ".gro":
-            dst_path = dst_path.with_suffix(".gro")
-        if not dst_path.is_absolute():
-            dst_path = self.scratch_dir / dst_path
-        shutil.copy(src_state.gro, dst_path)
-        dst_cpt = dst_path.with_suffix(".cpt")
-        if src_state.cpt is not None:
-            shutil.copy(src_state.cpt, dst_cpt)
-        elif dst_cpt.exists():
-            dst_cpt.unlink()
-        return GromacsState(dst_path, dst_cpt)
+    def clone_anchor(self, handle):
+        src_gro = Path(handle)
+        src_cpt = src_gro.with_suffix(".cpt")
+        dst_gro = self.scratch_dir / f"anchor_{self._uid()}.gro"
+        dst_gro.write_bytes(src_gro.read_bytes())
+        if src_cpt.exists():
+            dst_gro.with_suffix(".cpt").write_bytes(src_cpt.read_bytes())
+        return str(dst_gro)
 
-    def run_segment(self, input_state, output_prefix):
-        input_state = self.state(input_state)
-        output_name = Path(output_prefix).name
-        is_tau2 = output_name.startswith("tau2_")
-        output_prefix = self.scratch_dir / output_name
-        mdp = self.scratch_dir / f"{output_name}.mdp"
-        tpr = output_prefix.with_suffix(".tpr")
-        out_gro = output_prefix.with_suffix(".gro")
-        out_cpt = output_prefix.with_suffix(".cpt")
+    def run_segment(self, handle, n_steps, *, randomize_velocities, seed, device=None):
+        is_tau2 = not randomize_velocities
+        workdir = self._device_dir(device)
+        stem = f"seg_{self._uid()}"
+        prefix = workdir / stem
+        in_gro = Path(handle)
+        in_cpt = in_gro.with_suffix(".cpt")
+        mdp = workdir / f"{stem}.mdp"
+        tpr = prefix.with_suffix(".tpr")
+        out_gro = prefix.with_suffix(".gro")
+        out_cpt = prefix.with_suffix(".cpt")
 
         write_mdp(
-            mdp,
-            self.tau2_steps if is_tau2 else self.tau1_steps,
-            self.temperature,
-            self.mdp_controls,
-            generate_velocities=not is_tau2,
-            random_seed=RNG.randint(1, 2_000_000_000),
+            mdp, int(n_steps), self.temperature, self.mdp_controls,
+            generate_velocities=randomize_velocities, random_seed=int(seed),
         )
 
-        grompp_cmd = [
-            self.exe,
-            "grompp",
-            "-f",
-            str(mdp),
-            "-c",
-            str(input_state.gro),
-            "-p",
-            self.topology,
-            "-o",
-            str(tpr),
-            "-po",
-            str(output_prefix.with_suffix(".mdout.mdp")),
-            "-maxwarn",
-            str(self.maxwarn),
-            *self.grompp_args,
-        ]
-        if is_tau2 and input_state.cpt is not None:
-            grompp_cmd.extend(["-t", str(input_state.cpt)])
+        env = os.environ.copy()
+        if device is not None:
+            env["CUDA_VISIBLE_DEVICES"] = str(device)
 
-        self._run(grompp_cmd, "grompp")
+        grompp_cmd = [
+            self.exe, "grompp", "-f", str(mdp), "-c", str(in_gro), "-p", self.topology,
+            "-o", str(tpr), "-po", str(prefix.with_suffix(".mdout.mdp")),
+            "-maxwarn", str(self.maxwarn), *self.grompp_args,
+        ]
+        if is_tau2 and in_cpt.exists():
+            grompp_cmd.extend(["-t", str(in_cpt)])
+        self._run(grompp_cmd, "grompp", env)
 
         mdrun_cmd = [
-            self.exe,
-            "mdrun",
-            "-s",
-            str(tpr),
-            "-deffnm",
-            str(output_prefix),
-            "-c",
-            str(out_gro),
-            "-cpo",
-            str(out_cpt),
-            *self.mdrun_args,
+            self.exe, "mdrun", "-s", str(tpr), "-deffnm", str(prefix),
+            "-c", str(out_gro), "-cpo", str(out_cpt), *self.mdrun_args,
         ]
-        self._run(mdrun_cmd, "mdrun")
-        return GromacsState(out_gro, out_cpt)
+        self._run(mdrun_cmd, "mdrun", env)
+        return str(out_gro)
 
-    def load_coords(self, state):
-        return read_gro_coords(self.state(state).gro)
+    def get_coords(self, handle):
+        coords = read_gro_coords(handle)
+        if not np.all(np.isfinite(coords)):
+            raise ValueError(f"GROMACS segment produced non-finite coordinates: {handle}")
+        return coords
 
-    def _run(self, cmd: list[str], stage: str) -> None:
+    def release(self, handle):
+        gro = Path(handle)
+        for sibling in gro.parent.glob(gro.with_suffix("").name + ".*"):
+            try:
+                sibling.unlink()
+            except OSError:
+                pass
+
+    def _run(self, cmd, stage, env):
         try:
-            subprocess.run(cmd, check=True, capture_output=True, text=True)
+            subprocess.run(cmd, check=True, capture_output=True, text=True, env=env)
         except subprocess.CalledProcessError as exc:
             message = [
                 f"GROMACS {stage} failed with exit code {exc.returncode}.",
@@ -277,119 +244,6 @@ class GenericGromacsEngine:
             if exc.stderr:
                 message.append("stderr:\n" + exc.stderr[-4000:])
             raise RuntimeError("\n".join(message)) from exc
-
-
-class GenericPathGennieGromacs:
-    def __init__(
-        self,
-        *,
-        engine,
-        projection_fn,
-        convergence_fn,
-        sigma=0.1,
-        mode="escape",
-        target_projection=None,
-        projection_args=None,
-        convergence_args=None,
-        tau1_workers=1,
-        escape_metric="cv0",
-        reject_worse_tau2=False,
-        reject_worse_anchor=False,
-    ):
-        self.engine = engine
-        self.proj_fn = projection_fn
-        self.conv_fn = convergence_fn
-        self.mode = mode
-        self.sigma = sigma
-        self.target = target_projection
-        self.proj_args = projection_args or {}
-        self.conv_args = convergence_args or {}
-        self.tau1_workers = max(1, int(tau1_workers))
-        self.escape_metric = escape_metric
-        self.reject_worse_tau2 = bool(reject_worse_tau2)
-        self.reject_worse_anchor = bool(reject_worse_anchor)
-
-    def metric(self, cv, start_proj):
-        if self.mode == "escape":
-            if self.escape_metric == "distance_from_start":
-                return np.linalg.norm(cv - start_proj)
-            return float(cv[0])
-        return -np.linalg.norm(cv - self.target)
-
-    def run(self, initial_state, max_trial=20, max_cycle=1000, save_freq=10):
-        anchor_state = self.engine.copy_state(initial_state, "anchor.gro")
-        start_pos = self.engine.load_coords(anchor_state)
-        start_proj = self.proj_fn(start_pos, **self.proj_args)
-        anchor_pos = start_pos
-        anchor_cv = start_proj
-        anchor_metric = self.metric(anchor_cv, start_proj)
-
-        trajectory = []
-        metric_history = []
-
-        def run_trial(cycle, trial):
-            trial_input = self.engine.copy_state(anchor_state, f"trial_{trial}.gro")
-            tau1_state = self.engine.run_segment(trial_input, f"tau1_{cycle}_{trial}")
-            pos = self.engine.load_coords(tau1_state)
-            cv = self.proj_fn(pos, **self.proj_args)
-            return {"state": tau1_state, "metric": self.metric(cv, start_proj), "cv": cv}
-
-        for cycle in trange(max_cycle):
-            previous_anchor_state = anchor_state
-            workers = min(self.tau1_workers, max_trial)
-            if workers == 1:
-                trials = [run_trial(cycle, trial) for trial in range(max_trial)]
-            else:
-                with ThreadPoolExecutor(max_workers=workers) as executor:
-                    trials = list(executor.map(lambda trial: run_trial(cycle, trial), range(max_trial)))
-
-            metrics = np.array([trial["metric"] for trial in trials])
-            mmin = metrics.min()
-            mmax = metrics.max()
-            if abs(mmax - mmin) < 1e-12:
-                probs = np.ones(len(metrics)) / len(metrics)
-            else:
-                scaled = (metrics - mmin) / (mmax - mmin)
-                weights = np.exp((scaled - 1.0) / self.sigma)
-                probs = weights / weights.sum()
-
-            chosen = trials[np.random.choice(len(trials), p=probs)]
-            tau2_state = self.engine.run_segment(chosen["state"], f"tau2_{cycle}")
-            tau2_pos = self.engine.load_coords(tau2_state)
-            tau2_cv = self.proj_fn(tau2_pos, **self.proj_args)
-            tau2_metric = self.metric(tau2_cv, start_proj)
-
-            if self.reject_worse_tau2 and tau2_metric < chosen["metric"]:
-                anchor_state = chosen["state"]
-                pos = self.engine.load_coords(anchor_state)
-                cv = chosen["cv"]
-                metric = chosen["metric"]
-            else:
-                anchor_state = tau2_state
-                pos = tau2_pos
-                cv = tau2_cv
-                metric = tau2_metric
-
-            if self.reject_worse_anchor and metric < anchor_metric:
-                anchor_state = previous_anchor_state
-                pos = anchor_pos
-                cv = anchor_cv
-                metric = anchor_metric
-            else:
-                anchor_pos = pos
-                anchor_cv = cv
-                anchor_metric = metric
-            metric_history.append(metric)
-
-            if cycle % save_freq == 0:
-                print(f"Cycle {cycle}: metric={metric:.4f}, CV={cv}")
-                trajectory.append(pos.copy())
-
-            if self.conv_fn(pos, **self.conv_args):
-                print(f"Converged at cycle {cycle}")
-                break
-
-        return np.asarray(trajectory), np.asarray(metric_history)
 
 
 def run(case_dir: Path, config_name: str = "input.yaml") -> None:
@@ -438,27 +292,6 @@ def run(case_dir: Path, config_name: str = "input.yaml") -> None:
     mdrun_args = [str(arg) for arg in gmx_cfg.get("mdrun_args", [])]
     grompp_args, mdrun_args = split_grompp_only_args(grompp_args, mdrun_args)
 
-    write_mdp(
-        workdir / "tau1.mdp",
-        pg_cfg["tau1_steps"],
-        temperature,
-        mdp_controls,
-        generate_velocities=True,
-        random_seed=-1,
-    )
-    write_mdp(
-        workdir / "tau2.mdp",
-        pg_cfg["tau2_steps"],
-        temperature,
-        mdp_controls,
-        generate_velocities=False,
-        random_seed=-1,
-    )
-    print(
-        f"Using generated GROMACS mdp files: {workdir / 'tau1.mdp'} "
-        f"and {workdir / 'tau2.mdp'}"
-    )
-
     proj_fn = load_function(case_dir, cfg["projection"]["module"], cfg["projection"]["function"])
     conv_fn = load_function(case_dir, cfg["convergence"]["module"], cfg["convergence"]["function"])
 
@@ -475,47 +308,53 @@ def run(case_dir: Path, config_name: str = "input.yaml") -> None:
     projection_args = enrich_args(projection_args, topology_info)
     convergence_args = enrich_args(convergence_args, topology_info)
 
-    initial_cv = proj_fn(read_gro_coords(initial_structure), **projection_args)
-    print(f"Initial CV: {initial_cv}")
+    start_cv = np.asarray(proj_fn(read_gro_coords(initial_structure), **projection_args), dtype=float)
+    print(f"Initial CV: {start_cv}")
 
     mode = pg_cfg.get("mode", "escape")
-    target_projection = None
     if mode == "target":
         if "target_projection" not in pg_cfg:
             raise ValueError("pathgennie.mode is 'target', but pathgennie.target_projection is missing")
-        target_projection = np.asarray(pg_cfg["target_projection"], dtype=float)
-        if target_projection.ndim == 0:
-            target_projection = target_projection.reshape(1)
+        target_projection = np.asarray(pg_cfg["target_projection"], dtype=float).reshape(-1)
+        progress = TargetMetric(proj_fn, target_projection, projection_args=projection_args)
+    else:
+        progress = EscapeMetric(
+            proj_fn, start_cv, projection_args=projection_args,
+            escape_metric=pg_cfg.get("escape_metric", "cv0"),
+        )
 
-    engine = GenericGromacsEngine(
+    def convergence(coords: np.ndarray) -> bool:
+        return bool(conv_fn(coords, **convergence_args))
+
+    engine = CoreGromacsEngine(
         topology=topology,
         executable=executable,
         scratch_dir=scratch_dir,
-        tau1_steps=pg_cfg["tau1_steps"],
-        tau2_steps=pg_cfg["tau2_steps"],
         temperature=temperature,
         mdp_controls=mdp_controls,
         maxwarn=gmx_cfg.get("maxwarn", 1),
         grompp_args=grompp_args,
         mdrun_args=mdrun_args,
     )
-    runner = GenericPathGennieGromacs(
-        engine=engine,
-        projection_fn=proj_fn,
-        convergence_fn=conv_fn,
+
+    devices = pg_cfg.get("devices", gmx_cfg.get("devices"))
+    workers_per_device = int(pg_cfg.get("workers_per_device", pg_cfg.get("tau1_workers", 1)))
+    executor = ThreadDevicePool(devices=devices, workers_per_device=workers_per_device)
+
+    driver = PathGennieDriver(
+        engine, progress, convergence,
+        executor=executor,
         sigma=pg_cfg["sigma"],
-        mode=mode,
-        target_projection=target_projection,
-        projection_args=projection_args,
-        convergence_args=convergence_args,
-        tau1_workers=pg_cfg.get("tau1_workers", 1),
-        escape_metric=pg_cfg.get("escape_metric", "cv0"),
+        seed=pg_cfg.get("seed"),
         reject_worse_tau2=pg_cfg.get("reject_worse_tau2", False),
         reject_worse_anchor=pg_cfg.get("reject_worse_anchor", False),
+        verbosity=pg_cfg.get("verbosity", 1),
     )
 
-    traj, metrics = runner.run(
-        initial_state=str(initial_structure),
+    traj, metrics = driver.run(
+        str(initial_structure),
+        tau1=pg_cfg["tau1_steps"],
+        tau2=pg_cfg["tau2_steps"],
         max_trial=pg_cfg["max_trial"],
         max_cycle=pg_cfg["max_cycle"],
         save_freq=pg_cfg.get("save_freq", 10),

--- a/pathgennie/backends/gromacs/pg_gmx.py
+++ b/pathgennie/backends/gromacs/pg_gmx.py
@@ -352,19 +352,38 @@ def run(case_dir: Path, config_name: str = "input.yaml") -> None:
         verbosity=pg_cfg.get("verbosity", 1),
     )
 
-    traj, metrics = driver.run(
+    downstream = pg_cfg.get("downstream")
+    result = driver.run(
         str(initial_structure),
         tau1=pg_cfg["tau1_steps"],
         tau2=pg_cfg["tau2_steps"],
         max_trial=pg_cfg["max_trial"],
         max_cycle=pg_cfg["max_cycle"],
         save_freq=pg_cfg.get("save_freq", 10),
+        collect_seeds=bool(downstream),
     )
+    seed_handles = None
+    if downstream:
+        traj, metrics, seed_handles = result
+    else:
+        traj, metrics = result
 
     trajectory_path = output_dir / cfg.get("output", {}).get("trajectory", "reactive_path.xtc")
     metrics_path = output_dir / cfg.get("output", {}).get("metrics", "metrics.csv")
     write_trajectory(trajectory_path, topology_info, traj)
     write_metrics_csv(metrics_path, metrics)
+
+    # Optional downstream enhanced-sampling stage (uses scratch, so before cleanup).
+    if downstream:
+        from pathgennie.sampling.runner import make_scalar_cv, run_downstream
+        stage_cfg = dict(cfg.get(downstream, {}))
+        component = stage_cfg.pop("cv_component", 0)
+        scalar_cv = make_scalar_cv(proj_fn, projection_args, component)
+        run_downstream(
+            downstream, stage_cfg, engine=engine, traj=traj, metrics=metrics,
+            seed_handles=seed_handles, scalar_cv_fn=scalar_cv, output_dir=output_dir,
+        )
+
     shutil.rmtree(scratch_dir)
 
     print(f"Saved frames: {len(traj)}")

--- a/pathgennie/backends/gromacs/pg_gmx.py
+++ b/pathgennie/backends/gromacs/pg_gmx.py
@@ -27,6 +27,7 @@ import yaml
 from pathgennie.core.driver import PathGennieDriver
 from pathgennie.core.parallel import ThreadDevicePool
 from pathgennie.core.progress import EscapeMetric, TargetMetric
+from pathgennie.core.strategy import resolve_profile
 
 from .utils import (
     enrich_args,
@@ -260,7 +261,7 @@ def run(case_dir: Path, config_name: str = "input.yaml") -> None:
     output_dir.mkdir(parents=True, exist_ok=True)
 
     gmx_cfg = cfg["gromacs"]
-    pg_cfg = cfg["pathgennie"]
+    pg_cfg = resolve_profile(cfg["pathgennie"])
     topology = resolve_case_path(case_dir, gmx_cfg["topology"])
     initial_structure = resolve_case_path(case_dir, gmx_cfg["initial_structure"])
     executable = Path(gmx_cfg["executable"]).expanduser()

--- a/pathgennie/backends/openmm/engine.py
+++ b/pathgennie/backends/openmm/engine.py
@@ -1,0 +1,100 @@
+"""OpenMM in-process engine adapter for the PathGennie core driver.
+
+Wraps a single ``openmm.app.Simulation`` (one Context, one device) behind the
+:class:`pathgennie.core.engine.Engine` protocol so the shared
+:class:`~pathgennie.core.driver.PathGennieDriver` can run the OpenMM backend.
+
+A *handle* is an integer id into a cache of immutable OpenMM ``State`` snapshots.
+Because a ``State`` is immutable, ``clone_anchor`` can hand out a new id that
+shares the same snapshot — ``run_segment`` always ``setState``s, steps, and then
+stores a *new* snapshot, so trials never alias mutable state.  ``setState``/
+``getState`` round-trip positions, velocities **and periodic box vectors**, which
+fixes the box-desync issue in the original loop that only set the box at build
+time.
+
+For multi-GPU in-process execution, construct one ``OpenMMEngine`` per worker
+process (each with a Simulation pinned to its ``CudaDeviceIndex``); OpenMM
+Contexts are not thread-safe, so a process pool — not threads — is required.
+
+Reproducibility note: the driver's selection draws and the per-segment velocity
+randomisation are seeded and reproducible.  A *stochastic* integrator's noise
+stream (e.g. Langevin thermostat) is initialised at context creation and is not
+reliably re-seedable per segment in OpenMM, so bit-identical trajectories are
+only guaranteed with a deterministic integrator (e.g. Verlet).  The best-effort
+``setRandomNumberSeed`` below helps engines/platforms that honour it.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+import numpy as np
+from openmm import State, unit
+from openmm.app import Simulation
+
+from pathgennie.core.progress import ProgressVariable
+
+NM_TO_ANG = 10.0
+
+__all__ = ["OpenMMEngine"]
+
+
+class OpenMMEngine:
+    def __init__(self, simulation: Simulation, temperature: float):
+        self.sim = simulation
+        self.temperature = temperature * unit.kelvin  # type: ignore
+        self._cache: Dict[int, State] = {}
+        self._next_id = 0
+
+    def _store(self, state: State) -> int:
+        handle = self._next_id
+        self._next_id += 1
+        self._cache[handle] = state
+        return handle
+
+    def _snapshot(self) -> State:
+        return self.sim.context.getState(getPositions=True, getVelocities=True)
+
+    def create_state(self, positions, box_vectors=None) -> int:
+        """Initialise the cache from positions (and optional box); return a handle."""
+        self.sim.context.setPositions(positions)
+        if box_vectors is not None:
+            self.sim.context.setPeriodicBoxVectors(*box_vectors)
+        self.sim.context.setVelocitiesToTemperature(self.temperature)
+        return self._store(self._snapshot())
+
+    def clone_anchor(self, handle: int) -> int:
+        # State is immutable; sharing the snapshot is safe.
+        return self._store(self._cache[handle])
+
+    def run_segment(
+        self,
+        handle: int,
+        n_steps: int,
+        *,
+        randomize_velocities: bool,
+        seed: int,
+        device: Optional[int] = None,
+    ) -> int:
+        self.sim.context.setState(self._cache[handle])
+        # Seed the integrator's own RNG (e.g. Langevin thermostat noise) so a
+        # segment is reproducible; setVelocitiesToTemperature's seed only covers
+        # the initial velocity draw, not the noise injected during stepping.
+        try:
+            self.sim.integrator.setRandomNumberSeed(int(seed))
+        except AttributeError:  # integrator without an RNG (e.g. Verlet)
+            pass
+        if randomize_velocities:
+            self.sim.context.setVelocitiesToTemperature(self.temperature, int(seed))
+        self.sim.step(int(n_steps))
+        return self._store(self._snapshot())
+
+    def get_coords(self, handle: int) -> np.ndarray:
+        pos = self._cache[handle].getPositions(asNumpy=True).value_in_unit(unit.nanometer)  # type: ignore
+        coords = np.asarray(pos, dtype=float) * NM_TO_ANG
+        if not np.all(np.isfinite(coords)):
+            raise ValueError("OpenMM segment produced non-finite coordinates (unstable dynamics?)")
+        return coords
+
+    def release(self, handle: int) -> None:
+        self._cache.pop(handle, None)

--- a/pathgennie/backends/openmm/pg_omm.py
+++ b/pathgennie/backends/openmm/pg_omm.py
@@ -1,18 +1,32 @@
+"""OpenMM PathGennie runner.
+
+Thin wrapper that builds an :class:`OpenMMEngine` and the shared
+:class:`~pathgennie.core.driver.PathGennieDriver`.  The adaptive cycle, selection
+and convergence logic now live in :mod:`pathgennie.core`; this class only adapts
+the OpenMM-specific construction and preserves the original public API used by
+``pg_openmm.py``.
+
+PathGennie reference:
+'PathGennie: Rapid Generation of Rare Event Pathways via Direction-Guided
+Adaptive Sampling Using Ultrashort Monitored Trajectories', J. Chem. Theory
+Comput. 2025.
+"""
+
+from __future__ import annotations
+
 from typing import Callable, Dict, Optional
 
-import numpy as np  # type: ignore
-from openmm import unit  # type: ignore
-from openmm.app import Simulation  # type: ignore
-from tqdm.auto import trange
+import numpy as np
+from openmm.app import Simulation
+
+from pathgennie.core.driver import PathGennieDriver
+from pathgennie.core.parallel import SerialExecutor
+from pathgennie.core.progress import EscapeMetric, TargetMetric
+
+from .engine import OpenMMEngine
 
 
 class PathGennieMD:
-    """
-    PathGennie implementation based on:
-    'PathGennie: Rapid Generation of Rare Event Pathways via Direction-Guided Adaptive Sampling Using Ultrashort Monitored Trajectories'
-    J. Chem. Theory Comput. 2016, 12, 5, 2035-2043
-    """
-
     NM_TO_ANG = 10.0
 
     def __init__(
@@ -27,15 +41,14 @@ class PathGennieMD:
         escape_direction: str = "auto",
         temperature: float = 300.0,
         sigma: float = 0.5,
+        seed: Optional[int] = None,
     ):
         if mode not in ("escape", "target"):
-            raise ValueError("mode must be 'escape', 'target'")
+            raise ValueError("mode must be 'escape' or 'target'")
         if mode == "target" and target_projection is None:
             raise ValueError("target_projection required for target mode")
-        if mode == "target" and convergence_fn is None:
-            raise ValueError("convergence_fn required for target mode")
-        if mode == "escape" and convergence_fn is None:
-            raise ValueError("convergence_fn required for escape mode")
+        if convergence_fn is None:
+            raise ValueError("convergence_fn is required")
 
         self.sim = simulation
         self.mode = mode
@@ -44,15 +57,13 @@ class PathGennieMD:
         self.target = np.asarray(target_projection) if target_projection is not None else None
         self.converge_fn = convergence_fn
         self.converge_args = convergence_args or {}
-        self.escape_direction = escape_direction
-
-        # Temperature for velocity re-randomization
-        self.temperature = temperature * unit.kelvin  # type: ignore
+        self.temperature = temperature
         self.sigma = sigma
+        self.seed = seed
 
     def run(
         self,
-        initial_pos: np.ndarray,
+        initial_pos,
         tau1: int = 200,
         tau2: int = 200,
         max_trial: int = 20,
@@ -60,132 +71,31 @@ class PathGennieMD:
         save_freq: int = 10,
         verbosity: int = 1,
     ):
+        engine = OpenMMEngine(self.sim, self.temperature)
+        initial_handle = engine.create_state(initial_pos)
+        start_cv = np.asarray(self.proj_fn(engine.get_coords(initial_handle), **self.proj_args))
 
-        trajectory = []
-        metrics_history = []
+        if self.mode == "escape":
+            progress = EscapeMetric(
+                self.proj_fn, start_cv, projection_args=self.proj_args,
+                escape_metric="distance_from_start",
+            )
+        else:
+            progress = TargetMetric(self.proj_fn, self.target, projection_args=self.proj_args)
 
-        # ---- initialize system ----
-        self.sim.context.setPositions(initial_pos)
-        self.sim.context.setVelocitiesToTemperature(self.temperature)
+        converge_fn = self.converge_fn
+        converge_args = self.converge_args
 
-        # Initial anchor
-        anchor_state = self.sim.context.getState(getPositions=True, getVelocities=True)
-        pos = self._pos()
-        start_proj = self._proj(pos)
-        current_proj = start_proj
+        def convergence(coords: np.ndarray) -> bool:
+            return bool(converge_fn(coords, **converge_args))
 
-        # Metric definition
-        def metric(cv):
-            if self.mode == "escape":
-                return np.linalg.norm(cv - start_proj)
-            else:
-                # Progress is closeness to target
-                return -np.linalg.norm(cv - self.target)
-
-        current_metric = metric(current_proj)
-        cycle_iter = trange(max_cycle, desc="PathGennie") if verbosity >= 2 else range(max_cycle)
-
-        for cycle in cycle_iter:
-            trial_results = []
-
-            #  Run M trials ----
-            for _ in range(max_trial):
-                # Restore anchor positions but randomize velocities
-                self.sim.context.setState(anchor_state)
-                self.sim.context.setVelocitiesToTemperature(self.temperature)
-
-                # sampler segment
-                self.sim.step(tau1)
-
-                trial_pos = self._pos()
-                trial_proj = self._proj(trial_pos)
-                trial_metric = metric(trial_proj)
-
-                # Store the state and metric
-                # We need to store the FULL state after tau1 to continue it later
-                state_after_tau1 = self.sim.context.getState(getPositions=True, getVelocities=True)
-                trial_results.append(
-                    {"metric": trial_metric, "state": state_after_tau1, "pos": trial_pos, "proj": trial_proj}
-                )
-
-            raw_metrics = np.array([r["metric"] for r in trial_results])
-            m_min = np.min(raw_metrics)
-            m_max = np.max(raw_metrics)
-
-            # Avoid division by zero if all trials are identical
-            if (m_max - m_min) < 1e-9:
-                probs = np.ones(len(trial_results)) / len(trial_results)
-            else:
-                # 1. Scale metrics between 0 and 1
-                # 0 = worst trial of this batch, 1 = best trial
-                scaled_metrics = (raw_metrics - m_min) / (m_max - m_min)
-
-                # 2. Boltzmann Weighting on the scaled interval
-                # Shifted by 1.0 so the max weight is always exp(0) = 1
-                logits = (scaled_metrics - 1.0) / (self.sigma + 1e-12)
-                weights = np.exp(logits)
-                probs = weights / np.sum(weights)
-
-            chosen_idx = np.random.choice(len(trial_results), p=probs)
-            best_trial = trial_results[chosen_idx]
-
-            # ---- runner segment ----
-            self.sim.context.setState(best_trial["state"])
-
-            self.sim.step(tau2)
-
-            # Update anchor
-            anchor_state = self.sim.context.getState(getPositions=True, getVelocities=True)
-            pos = self._pos()
-            current_proj = self._proj(pos)
-            current_metric = metric(current_proj)
-            metrics_history.append(current_metric)
-
-            # ---- SAVE (after tau2) ----
-            if cycle % save_freq == 0:
-                trajectory.append(pos * self.NM_TO_ANG)
-                if verbosity:
-                    print(f"Cycle {cycle}: metric={current_metric:.4f}, CV={current_proj}")
-
-            # ---- CONVERGENCE ----
-            converge_fn = self.converge_fn
-            if converge_fn is None:
-                raise ValueError("convergence_fn is required for run()")
-
-            if self.mode == "escape":
-                if converge_fn(pos * self.NM_TO_ANG, **self.converge_args):
-                    if verbosity:
-                        print(f"\nEscape convergence reached at cycle {cycle}")
-                    break
-            else:  # mode == "target"
-                # For target mode, metric is -norm(cv - target), so norm < tol means metric > -tol
-                if converge_fn(pos * self.NM_TO_ANG, **self.converge_args):
-                    if verbosity:
-                        print(f"\nTarget convergence reached at cycle {cycle}")
-                    break
-
-            if verbosity >= 2 and cycle % 10 == 0 and cycle % save_freq != 0:
-                print(f"Cycle {cycle:4d}: metric={current_metric:.4f} (best of {max_trial})")
-
-        if verbosity:
-            print("Final metric:", current_metric)
-
-        return np.array(trajectory), np.array(metrics_history)
-
-    def _get_step_size_ps(self):
-        """Return integrator step size in picoseconds when available."""
-        try:
-            step_size = self.sim.integrator.getStepSize()
-            return step_size.value_in_unit(unit.picosecond)  # type: ignore
-        except Exception:
-            return 1.0
-
-    def _pos(self):
-        """Returns positions as raw numpy array in nanometers"""
-        p = self.sim.context.getState(getPositions=True).getPositions(asNumpy=True)
-        return p.value_in_unit(unit.nanometer)  # type: ignore
-
-    def _proj(self, pos):
-        """pos is raw numpy array in nm. Returns projection (CV) as numpy array."""
-        pos_ang = pos * self.NM_TO_ANG
-        return np.asarray(self.proj_fn(pos_ang, **self.proj_args))
+        driver = PathGennieDriver(
+            engine, progress, convergence,
+            executor=SerialExecutor(),
+            sigma=self.sigma, seed=self.seed, verbosity=verbosity,
+        )
+        return driver.run(
+            initial_handle,
+            tau1=tau1, tau2=tau2, max_trial=max_trial,
+            max_cycle=max_cycle, save_freq=save_freq,
+        )

--- a/pathgennie/backends/openmm/pg_omm.py
+++ b/pathgennie/backends/openmm/pg_omm.py
@@ -70,8 +70,10 @@ class PathGennieMD:
         max_cycle: int = 5000,
         save_freq: int = 10,
         verbosity: int = 1,
+        collect_seeds: bool = False,
     ):
         engine = OpenMMEngine(self.sim, self.temperature)
+        self.engine = engine  # exposed so a downstream stage can reuse it
         initial_handle = engine.create_state(initial_pos)
         start_cv = np.asarray(self.proj_fn(engine.get_coords(initial_handle), **self.proj_args))
 
@@ -98,4 +100,5 @@ class PathGennieMD:
             initial_handle,
             tau1=tau1, tau2=tau2, max_trial=max_trial,
             max_cycle=max_cycle, save_freq=save_freq,
+            collect_seeds=collect_seeds,
         )

--- a/pathgennie/backends/openmm/pg_openmm.py
+++ b/pathgennie/backends/openmm/pg_openmm.py
@@ -124,7 +124,8 @@ def run(case_dir: Path, config_name: str = "input.yaml") -> None:
         sigma=pg_cfg.get("sigma", 0.05),
         seed=pg_cfg.get("seed"),
     )
-    trajectory, metrics = runner.run(
+    downstream = pg_cfg.get("downstream")
+    result = runner.run(
         initial_pos=AmberInpcrdFile(str(initial_restart)).positions,  # type: ignore
         tau1=pg_cfg["tau1_steps"],
         tau2=pg_cfg["tau2_steps"],
@@ -132,7 +133,13 @@ def run(case_dir: Path, config_name: str = "input.yaml") -> None:
         max_cycle=pg_cfg["max_cycle"],
         save_freq=pg_cfg.get("save_freq", 1),
         verbosity=pg_cfg.get("verbosity", 1),
+        collect_seeds=bool(downstream),
     )
+    seed_handles = None
+    if downstream:
+        trajectory, metrics, seed_handles = result
+    else:
+        trajectory, metrics = result
 
     trajectory_path = output_dir / cfg.get("output", {}).get("trajectory", "reactive_path.dcd")
     metrics_path = output_dir / cfg.get("output", {}).get("metrics", "metrics.csv")
@@ -140,6 +147,16 @@ def run(case_dir: Path, config_name: str = "input.yaml") -> None:
         trajectory = wrap_frames_pbc(trajectory, topology_info)
     write_trajectory(trajectory_path, topology_info, trajectory)
     write_metrics_csv(metrics_path, metrics)
+
+    if downstream:
+        from pathgennie.sampling.runner import make_scalar_cv, run_downstream
+        stage_cfg = dict(cfg.get(downstream, {}))
+        component = stage_cfg.pop("cv_component", 0)
+        scalar_cv = make_scalar_cv(proj_fn, projection_args, component)
+        run_downstream(
+            downstream, stage_cfg, engine=runner.engine, traj=trajectory, metrics=metrics,
+            seed_handles=seed_handles, scalar_cv_fn=scalar_cv, output_dir=output_dir,
+        )
     print(f"Saved frames: {len(trajectory)}")
     print(f"Metric samples: {len(metrics)}")
     print(f"Reactive path: {trajectory_path}")

--- a/pathgennie/backends/openmm/pg_openmm.py
+++ b/pathgennie/backends/openmm/pg_openmm.py
@@ -23,6 +23,8 @@ from pathgennie.backends.amber.utils import (
     write_trajectory,
 )
 
+from pathgennie.core.strategy import resolve_profile
+
 from .pg_omm import PathGennieMD
 
 
@@ -65,7 +67,7 @@ def run(case_dir: Path, config_name: str = "input.yaml") -> None:
     output_dir.mkdir(parents=True, exist_ok=True)
 
     openmm_cfg = cfg["openmm"]
-    pg_cfg = cfg["pathgennie"]
+    pg_cfg = resolve_profile(cfg["pathgennie"])
     topology = resolve_case_path(case_dir, openmm_cfg["topology"])
     initial_restart = resolve_case_path(case_dir, openmm_cfg["initial_restart"])
 
@@ -120,6 +122,7 @@ def run(case_dir: Path, config_name: str = "input.yaml") -> None:
         convergence_args=convergence_args,
         temperature=temperature,
         sigma=pg_cfg.get("sigma", 0.05),
+        seed=pg_cfg.get("seed"),
     )
     trajectory, metrics = runner.run(
         initial_pos=AmberInpcrdFile(str(initial_restart)).positions,  # type: ignore

--- a/pathgennie/core/__init__.py
+++ b/pathgennie/core/__init__.py
@@ -1,1 +1,24 @@
 """Core PathGennie algorithms and shared abstractions."""
+
+from .driver import PathGennieDriver, TrialResult
+from .engine import Engine, Handle
+from .parallel import ParallelExecutor, SerialExecutor, ThreadDevicePool, resolve_devices
+from .progress import CallableProjection, EscapeMetric, ProgressVariable, TargetMetric
+from .selection import selection_probs, softmax_select
+
+__all__ = [
+    "PathGennieDriver",
+    "TrialResult",
+    "Engine",
+    "Handle",
+    "ParallelExecutor",
+    "SerialExecutor",
+    "ThreadDevicePool",
+    "resolve_devices",
+    "CallableProjection",
+    "EscapeMetric",
+    "ProgressVariable",
+    "TargetMetric",
+    "selection_probs",
+    "softmax_select",
+]

--- a/pathgennie/core/driver.py
+++ b/pathgennie/core/driver.py
@@ -157,6 +157,13 @@ class PathGennieDriver:
             anchor, anchor_coords, anchor_cv, anchor_metric = new_anchor, coords, cv, metric
             metric_history.append(metric)
 
+            # Let adaptive progress variables (e.g. SPIB) buffer the path and
+            # retrain on the fly. Done once per cycle on the committed anchor so
+            # the CV is stable within a cycle's project/metric calls.
+            observe = getattr(self.progress, "observe", None)
+            if observe is not None:
+                observe(coords, cycle)
+
             if cycle % save_freq == 0:
                 trajectory.append(coords.copy())
                 last_saved_cycle = cycle

--- a/pathgennie/core/driver.py
+++ b/pathgennie/core/driver.py
@@ -86,11 +86,19 @@ class PathGennieDriver:
         max_trial: int,
         max_cycle: int,
         save_freq: int = 10,
+        collect_seeds: bool = False,
     ):
         """Run the adaptive cycle and return ``(trajectory, metrics)`` arrays.
 
         ``trajectory`` has shape ``(n_saved, n_atoms, 3)`` in Angstrom;
         ``metrics`` has shape ``(n_cycles,)``.
+
+        When ``collect_seeds`` is True, an independent clone of the committed
+        anchor is retained for every saved frame and the call returns
+        ``(trajectory, metrics, seed_handles)`` — restartable seeds aligned with
+        the trajectory frames, for handing to a downstream sampling stage
+        (e.g. Weighted Ensemble). Default behaviour and the 2-tuple return are
+        unchanged.
         """
 
         anchor = initial_handle
@@ -99,7 +107,13 @@ class PathGennieDriver:
 
         trajectory: List[np.ndarray] = []
         metric_history: List[float] = []
+        seed_handles: List[Handle] = []
         last_saved_cycle = -1
+
+        def save_frame(coords: np.ndarray, handle: Handle) -> None:
+            trajectory.append(coords.copy())
+            if collect_seeds:
+                seed_handles.append(self.engine.clone_anchor(handle))
 
         def worker(trial_index: int, device: Optional[int]) -> TrialResult:
             handle = self.engine.clone_anchor(anchor)
@@ -165,7 +179,7 @@ class PathGennieDriver:
                 observe(coords, cycle)
 
             if cycle % save_freq == 0:
-                trajectory.append(coords.copy())
+                save_frame(coords, anchor)
                 last_saved_cycle = cycle
                 if self.verbosity:
                     print(f"Cycle {cycle}: metric={metric:.4f}, CV={cv}")
@@ -173,7 +187,7 @@ class PathGennieDriver:
             if self.convergence_fn(coords):
                 converged_at = cycle
                 if last_saved_cycle != cycle:  # always keep the converged frame
-                    trajectory.append(coords.copy())
+                    save_frame(coords, anchor)
                 if self.verbosity:
                     print(f"Converged at cycle {cycle}")
                 break
@@ -182,4 +196,6 @@ class PathGennieDriver:
             tail = f" (converged at {converged_at})" if converged_at is not None else ""
             print(f"Final metric: {anchor_metric:.4f}{tail}")
 
+        if collect_seeds:
+            return np.asarray(trajectory), np.asarray(metric_history), seed_handles
         return np.asarray(trajectory), np.asarray(metric_history)

--- a/pathgennie/core/driver.py
+++ b/pathgennie/core/driver.py
@@ -1,0 +1,178 @@
+"""Backend-independent PathGennie adaptive-sampling driver.
+
+This is the single implementation of the cycle that the OpenMM, AMBER and
+GROMACS backends previously each carried their own copy of:
+
+    for cycle in range(max_cycle):
+        run N samplers (tau1) from the anchor with fresh velocities   # swarm
+        score each by progress in CV space and softmax-select one     # selection
+        extend the chosen sampler for tau2 (runner)                   # commit
+        update the anchor, optionally rejecting a worse candidate
+        check convergence
+
+The swarm is evaluated through a :class:`ParallelExecutor`, so spreading the
+``N`` trials across multiple GPUs is a matter of passing a device pool — the
+selection/anchor logic here is untouched by the degree of parallelism.
+
+Correctness fixes relative to the original backends:
+
+* a single master RNG (``seed``) drives both per-segment seeds and the selection
+  draw, so a run is reproducible;
+* the final, converged frame is always saved (the OpenMM loop could skip it when
+  ``cycle % save_freq != 0``);
+* trial handles are released each cycle so scratch usage stays bounded.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, List, Optional
+
+import numpy as np
+
+from .engine import Engine, Handle
+from .parallel import ParallelExecutor, SerialExecutor
+from .progress import ProgressVariable
+from .selection import softmax_select
+
+__all__ = ["PathGennieDriver", "TrialResult"]
+
+
+@dataclass
+class TrialResult:
+    handle: Handle
+    cv: np.ndarray
+    metric: float
+    coords: np.ndarray
+
+
+class PathGennieDriver:
+    def __init__(
+        self,
+        engine: Engine,
+        progress: ProgressVariable,
+        convergence_fn: Callable[[np.ndarray], bool],
+        *,
+        executor: Optional[ParallelExecutor] = None,
+        sigma: float = 0.1,
+        seed: Optional[int] = None,
+        reject_worse_tau2: bool = False,
+        reject_worse_anchor: bool = False,
+        verbosity: int = 1,
+    ):
+        self.engine = engine
+        self.progress = progress
+        self.convergence_fn = convergence_fn
+        self.executor = executor or SerialExecutor()
+        self.sigma = float(sigma)
+        self.rng = np.random.default_rng(seed)
+        self.reject_worse_tau2 = bool(reject_worse_tau2)
+        self.reject_worse_anchor = bool(reject_worse_anchor)
+        self.verbosity = int(verbosity)
+
+    def _seed(self) -> int:
+        return int(self.rng.integers(1, 2_147_483_647))
+
+    def _evaluate(self, coords: np.ndarray):
+        cv = np.asarray(self.progress.project(coords), dtype=float)
+        return cv, float(self.progress.metric(cv))
+
+    def run(
+        self,
+        initial_handle: Handle,
+        *,
+        tau1: int,
+        tau2: int,
+        max_trial: int,
+        max_cycle: int,
+        save_freq: int = 10,
+    ):
+        """Run the adaptive cycle and return ``(trajectory, metrics)`` arrays.
+
+        ``trajectory`` has shape ``(n_saved, n_atoms, 3)`` in Angstrom;
+        ``metrics`` has shape ``(n_cycles,)``.
+        """
+
+        anchor = initial_handle
+        anchor_coords = self.engine.get_coords(anchor)
+        anchor_cv, anchor_metric = self._evaluate(anchor_coords)
+
+        trajectory: List[np.ndarray] = []
+        metric_history: List[float] = []
+        last_saved_cycle = -1
+
+        def worker(trial_index: int, device: Optional[int]) -> TrialResult:
+            handle = self.engine.clone_anchor(anchor)
+            seg = self.engine.run_segment(
+                handle, tau1, randomize_velocities=True, seed=self._seed(), device=device
+            )
+            coords = self.engine.get_coords(seg)
+            cv, metric = self._evaluate(coords)
+            return TrialResult(handle=seg, cv=cv, metric=metric, coords=coords)
+
+        converged_at: Optional[int] = None
+        for cycle in range(max_cycle):
+            previous_anchor = anchor
+
+            trials = self.executor.map(worker, list(range(max_trial)))
+            metrics = np.array([t.metric for t in trials], dtype=float)
+            chosen_idx = softmax_select(metrics, self.sigma, self.rng)
+            chosen = trials[chosen_idx]
+
+            # ---- runner (tau2) from the chosen sampler ----
+            tau2_handle = self.engine.run_segment(
+                chosen.handle, tau2, randomize_velocities=False,
+                seed=self._seed(), device=self.executor.devices[0],
+            )
+            tau2_coords = self.engine.get_coords(tau2_handle)
+            tau2_cv, tau2_metric = self._evaluate(tau2_coords)
+
+            # ---- candidate selection (optional rejection of a worse runner) ----
+            if self.reject_worse_tau2 and tau2_metric < chosen.metric:
+                cand_handle, cand_coords, cand_cv, cand_metric = (
+                    chosen.handle, chosen.coords, chosen.cv, chosen.metric,
+                )
+                self.engine.release(tau2_handle)
+            else:
+                cand_handle, cand_coords, cand_cv, cand_metric = (
+                    tau2_handle, tau2_coords, tau2_cv, tau2_metric,
+                )
+
+            # ---- optional rejection vs the existing anchor ----
+            if self.reject_worse_anchor and cand_metric < anchor_metric:
+                self.engine.release(cand_handle)
+                new_anchor, coords, cv, metric = (
+                    previous_anchor, anchor_coords, anchor_cv, anchor_metric,
+                )
+            else:
+                new_anchor, coords, cv, metric = cand_handle, cand_coords, cand_cv, cand_metric
+
+            # ---- release everything we are not keeping ----
+            for index, trial in enumerate(trials):
+                if trial.handle is not new_anchor and not (index == chosen_idx and cand_handle is chosen.handle):
+                    self.engine.release(trial.handle)
+            if new_anchor is not previous_anchor and previous_anchor is not initial_handle:
+                self.engine.release(previous_anchor)
+
+            anchor, anchor_coords, anchor_cv, anchor_metric = new_anchor, coords, cv, metric
+            metric_history.append(metric)
+
+            if cycle % save_freq == 0:
+                trajectory.append(coords.copy())
+                last_saved_cycle = cycle
+                if self.verbosity:
+                    print(f"Cycle {cycle}: metric={metric:.4f}, CV={cv}")
+
+            if self.convergence_fn(coords):
+                converged_at = cycle
+                if last_saved_cycle != cycle:  # always keep the converged frame
+                    trajectory.append(coords.copy())
+                if self.verbosity:
+                    print(f"Converged at cycle {cycle}")
+                break
+
+        if self.verbosity:
+            tail = f" (converged at {converged_at})" if converged_at is not None else ""
+            print(f"Final metric: {anchor_metric:.4f}{tail}")
+
+        return np.asarray(trajectory), np.asarray(metric_history)

--- a/pathgennie/core/engine.py
+++ b/pathgennie/core/engine.py
@@ -1,0 +1,66 @@
+"""Backend-independent engine protocol for PathGennie.
+
+The OpenMM, AMBER and GROMACS backends each implement the same adaptive cycle
+but with engine-specific state handling.  This module defines the thin contract
+the shared driver (:mod:`pathgennie.core.driver`) needs from any backend so the
+cycle/selection logic only has to be written once.
+
+A *handle* is an opaque, engine-defined token that names a stored simulation
+state.  For the subprocess backends it is typically a restart-file path
+(``rst7``/``gro``); for the in-process OpenMM worker pool it is an id into a
+per-worker state cache.  The driver never inspects a handle, it only passes it
+back to the engine.
+"""
+
+from __future__ import annotations
+
+from typing import Hashable, Optional, Protocol, runtime_checkable
+
+import numpy as np
+
+Handle = Hashable
+
+__all__ = ["Handle", "Engine"]
+
+
+@runtime_checkable
+class Engine(Protocol):
+    """Minimal MD-engine interface used by :class:`PathGennieDriver`."""
+
+    def clone_anchor(self, handle: Handle) -> Handle:
+        """Return a fresh, independent handle initialised from ``handle``.
+
+        Used to seed each sampler trial from the current anchor without the
+        trials clobbering one another's state/scratch files.
+        """
+        ...
+
+    def run_segment(
+        self,
+        handle: Handle,
+        n_steps: int,
+        *,
+        randomize_velocities: bool,
+        seed: int,
+        device: Optional[int] = None,
+    ) -> Handle:
+        """Propagate ``handle`` for ``n_steps`` and return the resulting handle.
+
+        ``randomize_velocities`` selects samplers (τ1, fresh Maxwell-Boltzmann
+        velocities) vs runners (τ2, continued velocities).  ``seed`` makes the
+        segment reproducible; ``device`` is the GPU index when a device pool is
+        in use (``None`` lets the engine choose).
+        """
+        ...
+
+    def get_coords(self, handle: Handle) -> np.ndarray:
+        """Return positions for ``handle`` as an ``(n_atoms, 3)`` array in Angstrom."""
+        ...
+
+    def release(self, handle: Handle) -> None:
+        """Release any resources (scratch files / cache entry) for ``handle``.
+
+        Implementations must tolerate being called with an already-released or
+        anchor handle (no-op) so the driver can release trials unconditionally.
+        """
+        ...

--- a/pathgennie/core/parallel.py
+++ b/pathgennie/core/parallel.py
@@ -1,0 +1,110 @@
+"""Parallel execution of swarm trials across devices.
+
+The driver evaluates ``N`` independent sampler trials per cycle (and ``K*N`` once
+beam/RRT policies are added).  Historically the AMBER/GROMACS backends ran these
+through a bare ``ThreadPoolExecutor`` with **no device assignment**, so every
+worker contended for GPU 0.  This module replaces that with a small executor
+abstraction that round-robins a *pool of devices* across the trials.
+
+An executor maps a ``worker_fn(item, device)`` over a list of work items, where
+``device`` is the GPU index (or ``None``) the trial should run on.  Keeping the
+device-assignment policy here means the selection/cycle logic in
+:mod:`pathgennie.core.driver` is identical regardless of how many GPUs are
+present, and all three backends share one code path.
+
+Two executors are provided:
+
+* :class:`SerialExecutor` — single device, no threads; the reference path that
+  ``ProcessDevicePool``/``ThreadDevicePool`` must match for a fixed seed.
+* :class:`ThreadDevicePool` — a thread per (device x workers_per_device) slot,
+  suitable for the subprocess backends (AMBER ``pmemd.cuda`` / GROMACS
+  ``gmx mdrun``) where the GIL is released during ``subprocess.run`` and each
+  worker exports ``CUDA_VISIBLE_DEVICES`` for its device.
+
+The in-process OpenMM process pool (one long-lived CUDA Context per GPU) is a
+specialisation built on the same ``ParallelExecutor`` contract; see
+``pathgennie/backends/openmm`` for that wiring.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from typing import Callable, List, Optional, Protocol, Sequence, TypeVar
+
+T = TypeVar("T")
+R = TypeVar("R")
+
+__all__ = ["ParallelExecutor", "SerialExecutor", "ThreadDevicePool", "resolve_devices"]
+
+
+def resolve_devices(devices: Optional[Sequence[int]]) -> List[Optional[int]]:
+    """Normalise a device spec into a list usable for round-robin assignment.
+
+    ``None`` or an empty sequence means "let the engine choose" (single slot,
+    device ``None``).
+    """
+
+    if not devices:
+        return [None]
+    return [int(d) for d in devices]
+
+
+class ParallelExecutor(Protocol):
+    """Map ``worker_fn(item, device)`` over ``items`` preserving input order."""
+
+    devices: List[Optional[int]]
+
+    def map(self, worker_fn: Callable[[T, Optional[int]], R], items: Sequence[T]) -> List[R]:
+        ...
+
+    def shutdown(self) -> None:
+        ...
+
+
+class SerialExecutor:
+    """Run all trials sequentially on a single device (reference implementation)."""
+
+    def __init__(self, device: Optional[int] = None):
+        self.devices: List[Optional[int]] = [device]
+
+    def map(self, worker_fn: Callable[[T, Optional[int]], R], items: Sequence[T]) -> List[R]:
+        device = self.devices[0]
+        return [worker_fn(item, device) for item in items]
+
+    def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+class ThreadDevicePool:
+    """Round-robin trials over ``devices`` using a thread pool.
+
+    Each work item ``i`` is assigned ``devices[i % len(devices)]`` so the swarm
+    is spread evenly across GPUs.  ``workers_per_device`` allows more than one
+    concurrent segment per GPU (useful for small systems that under-fill a GPU).
+    Output order matches input order.
+    """
+
+    def __init__(self, devices: Optional[Sequence[int]] = None, workers_per_device: int = 1):
+        self.devices = resolve_devices(devices)
+        self.workers_per_device = max(1, int(workers_per_device))
+        self._max_workers = len(self.devices) * self.workers_per_device
+
+    def map(self, worker_fn: Callable[[T, Optional[int]], R], items: Sequence[T]) -> List[R]:
+        items = list(items)
+        if not items:
+            return []
+        n_workers = min(self._max_workers, len(items))
+        if n_workers == 1:
+            device = self.devices[0]
+            return [worker_fn(item, device) for item in items]
+
+        def run(indexed_item):
+            index, item = indexed_item
+            device = self.devices[index % len(self.devices)]
+            return worker_fn(item, device)
+
+        with ThreadPoolExecutor(max_workers=n_workers) as pool:
+            return list(pool.map(run, enumerate(items)))
+
+    def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass

--- a/pathgennie/core/policy.py
+++ b/pathgennie/core/policy.py
@@ -1,0 +1,50 @@
+"""Exploration policies for PathGennie.
+
+The greedy/anchor cycle in :class:`pathgennie.core.driver.PathGennieDriver` is one
+*exploration policy*: at every step it expands a single anchor and aims at a fixed
+escape/target metric.  Richer non-linear search — Rapidly-exploring Random Trees
+(RRT) and RRT-Connect (:mod:`pathgennie.search.rrt`) — expand *different* tree
+nodes toward *random* CV targets, which lets the search backtrack, change
+direction, and move orthogonally to a hand-crafted CV.
+
+This module defines the thin :class:`ExplorerPolicy` protocol those searchers
+share so they remain interchangeable, plus :class:`GreedyPolicy`, the trivial
+policy that reproduces the driver's behaviour (always expand the current node,
+always aim at the global metric).
+
+A policy only decides *which node to expand and what CV target to aim at*; running
+the swarm and selecting a sampler is still done with the shared
+:class:`~pathgennie.core.engine.Engine` and
+:func:`~pathgennie.core.selection.softmax_select`, so policies never duplicate MD
+or selection logic.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Protocol
+
+import numpy as np
+
+__all__ = ["ExplorerPolicy", "GreedyPolicy"]
+
+
+class ExplorerPolicy(Protocol):
+    """Decide the next (node, CV-target) to expand from a collection of nodes."""
+
+    def propose(self, nodes, rng: np.random.Generator):
+        """Return ``(node, target_cv)``: the node to expand and the CV to aim at."""
+        ...
+
+
+class GreedyPolicy:
+    """Always expand the most recently committed node toward a fixed target.
+
+    Reproduces :class:`PathGennieDriver`'s behaviour: ``target_cv`` is a constant
+    (or ``None`` for a pure escape metric handled by the progress variable).
+    """
+
+    def __init__(self, target_cv: Optional[np.ndarray] = None):
+        self.target_cv = None if target_cv is None else np.asarray(target_cv, dtype=float)
+
+    def propose(self, nodes, rng: np.random.Generator):
+        return nodes[-1], self.target_cv

--- a/pathgennie/core/progress.py
+++ b/pathgennie/core/progress.py
@@ -1,0 +1,88 @@
+"""Progress variables and metrics for PathGennie.
+
+A :class:`ProgressVariable` couples a CV projection ``project(coords) -> cv`` with
+a scalar ``metric(cv) -> float`` where *higher is better*.  The two built-in
+metrics reproduce the original backends:
+
+* :class:`EscapeMetric` — maximise distance from the start CV (escape a minimum /
+  blind exploration).  ``escape_metric="cv0"`` keeps the legacy behaviour of just
+  maximising the first CV component.
+* :class:`TargetMetric` — minimise distance to a target CV (directed exploration);
+  the metric is the negated Euclidean distance.
+
+These wrap, verbatim, the logic in ``pg_omm.py:78-83`` and
+``pg_amber.py:155-160`` so behaviour is preserved while removing duplication.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional, Protocol
+
+import numpy as np
+
+__all__ = ["ProgressVariable", "EscapeMetric", "TargetMetric", "CallableProjection"]
+
+
+class ProgressVariable(Protocol):
+    """Projection + scalar progress metric used to score swarm trials."""
+
+    def project(self, coords: np.ndarray) -> np.ndarray:
+        """Map ``(n_atoms, 3)`` Angstrom coordinates to a CV vector."""
+        ...
+
+    def metric(self, cv: np.ndarray) -> float:
+        """Score a CV vector; larger means more progress."""
+        ...
+
+
+class CallableProjection:
+    """Adapt a plain ``projection_fn(coords, **kwargs)`` to ``project``."""
+
+    def __init__(self, projection_fn: Callable[..., np.ndarray], projection_args: Optional[dict] = None):
+        self._fn = projection_fn
+        self._args = projection_args or {}
+
+    def project(self, coords: np.ndarray) -> np.ndarray:
+        return np.asarray(self._fn(coords, **self._args), dtype=float)
+
+
+class EscapeMetric(CallableProjection):
+    """Maximise progress away from the starting CV."""
+
+    def __init__(
+        self,
+        projection_fn: Callable[..., np.ndarray],
+        start_cv: np.ndarray,
+        *,
+        projection_args: Optional[dict] = None,
+        escape_metric: str = "distance_from_start",
+    ):
+        super().__init__(projection_fn, projection_args)
+        self.start_cv = np.asarray(start_cv, dtype=float)
+        if escape_metric not in ("distance_from_start", "cv0"):
+            raise ValueError("escape_metric must be 'distance_from_start' or 'cv0'")
+        self.escape_metric = escape_metric
+
+    def metric(self, cv: np.ndarray) -> float:
+        cv = np.asarray(cv, dtype=float)
+        if self.escape_metric == "cv0":
+            return float(cv.ravel()[0])
+        return float(np.linalg.norm(cv - self.start_cv))
+
+
+class TargetMetric(CallableProjection):
+    """Minimise distance to a target CV (returned negated so higher is better)."""
+
+    def __init__(
+        self,
+        projection_fn: Callable[..., np.ndarray],
+        target_cv: np.ndarray,
+        *,
+        projection_args: Optional[dict] = None,
+    ):
+        super().__init__(projection_fn, projection_args)
+        self.target_cv = np.asarray(target_cv, dtype=float)
+
+    def metric(self, cv: np.ndarray) -> float:
+        cv = np.asarray(cv, dtype=float)
+        return float(-np.linalg.norm(cv - self.target_cv))

--- a/pathgennie/core/selection.py
+++ b/pathgennie/core/selection.py
@@ -1,0 +1,67 @@
+"""Selection logic for PathGennie swarms.
+
+The same Boltzmann/softmax selection over per-trial progress metrics was
+previously duplicated across the OpenMM, AMBER and GROMACS backends
+(``pg_omm.py``, ``pg_amber.py``, ``pg_gmx.py``).  It now lives here as the single
+source of truth so the behaviour is identical regardless of backend and can be
+unit tested in isolation.
+
+Given a batch of trial metrics (higher == better progress), the metrics are
+min-max scaled onto ``[0, 1]`` and converted to weights ``exp((scaled - 1)/sigma)``.
+Shifting by ``-1`` keeps the largest argument at ``0`` so ``exp`` never overflows.
+``sigma`` controls exploration: small ``sigma`` approaches ``argmax`` (greedy),
+large ``sigma`` approaches a uniform draw.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+__all__ = ["selection_probs", "softmax_select"]
+
+
+def selection_probs(metrics: np.ndarray, sigma: float) -> np.ndarray:
+    """Return normalized selection probabilities for a batch of trial metrics.
+
+    Parameters
+    ----------
+    metrics:
+        1-D array of progress metrics (higher is better).
+    sigma:
+        Selection temperature; must be > 0.
+
+    Notes
+    -----
+    If every metric is (numerically) identical the result is a uniform
+    distribution, matching the degenerate-batch behaviour of the original
+    backends.
+    """
+
+    metrics = np.asarray(metrics, dtype=float).ravel()
+    if metrics.size == 0:
+        raise ValueError("metrics must be non-empty")
+    if not np.all(np.isfinite(metrics)):
+        raise ValueError("metrics contains non-finite values")
+    if sigma <= 0.0:
+        raise ValueError("sigma must be > 0")
+
+    m_min = float(metrics.min())
+    m_max = float(metrics.max())
+    if (m_max - m_min) < 1e-9:
+        return np.full(metrics.shape, 1.0 / metrics.size)
+
+    scaled = (metrics - m_min) / (m_max - m_min)
+    weights = np.exp((scaled - 1.0) / sigma)
+    return weights / weights.sum()
+
+
+def softmax_select(metrics: np.ndarray, sigma: float, rng: np.random.Generator) -> int:
+    """Draw a single trial index using :func:`selection_probs`.
+
+    ``rng`` is an explicit :class:`numpy.random.Generator` so runs are
+    reproducible from a single master seed (the original code used NumPy's
+    global RNG, which made selection non-reproducible).
+    """
+
+    probs = selection_probs(metrics, sigma)
+    return int(rng.choice(probs.size, p=probs))

--- a/pathgennie/core/strategy.py
+++ b/pathgennie/core/strategy.py
@@ -1,0 +1,163 @@
+"""Goal-driven run profiles for PathGennie.
+
+PathGennie was designed as a *greedy* sampler of **ultrashort** (tens of fs)
+trajectories, optimised for the rapid discovery of candidate transition paths to
+seed later path-sampling.  That regime is deliberately different from what is
+needed when the goal shifts to *quantitative* sampling — free-energy surfaces or
+kinetics — where a data-driven CV (SPIB) and downstream enhanced sampling (WE,
+OPES) typically require **longer** segments and more data.
+
+Rather than hard-code one regime, a :class:`RunProfile` bundles the choices that
+should move together for a given goal: segment lengths (``tau1``/``tau2``),
+selection policy, CV type (geometric vs learned), and which downstream stage the
+run feeds.  Two presets are provided; ``resolve_profile`` overlays a profile's
+defaults *under* whatever the user set explicitly (explicit always wins), so
+existing configs are unchanged and a user can opt in with ``profile: discovery``
+or ``profile: sampling`` in ``input.yaml``.
+
+``check_learned_cv_segment_length`` encodes the caveat that a learned CV usually
+needs trajectories long enough to contain real relaxation, warning when the
+configured segments look too short for that goal.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "RunProfile",
+    "DISCOVERY",
+    "SAMPLING",
+    "PROFILES",
+    "get_profile",
+    "resolve_profile",
+    "check_learned_cv_segment_length",
+]
+
+
+@dataclass(frozen=True)
+class RunProfile:
+    """A coherent set of defaults for a sampling goal.
+
+    Attributes
+    ----------
+    goal:
+        ``"discovery"`` (fast candidate paths) or ``"sampling"`` (quantitative
+        free energy / kinetics).
+    selection:
+        Per-cycle policy: ``greedy`` | ``softmax`` | ``beam`` | ``rrt``.
+    cv:
+        ``geometric`` (hand-crafted projection) or ``learned`` (SPIB on the fly).
+    downstream:
+        Enhanced-sampling stage the run feeds: ``None`` | ``weighted_ensemble``
+        | ``opes``.
+    min_learned_cv_segment_ps:
+        Below this per-cycle MD time, a learned CV is flagged as likely
+        under-resolved.
+    """
+
+    name: str
+    goal: str
+    selection: str = "softmax"
+    cv: str = "geometric"
+    tau1_steps: int = 2
+    tau2_steps: int = 8
+    max_trial: int = 15
+    sigma: float = 0.1
+    downstream: Optional[str] = None
+    min_learned_cv_segment_ps: float = 0.1
+
+
+# Fast candidate-path discovery: the original PathGennie regime (greedy on
+# ultrashort, geometric-CV trajectories).
+DISCOVERY = RunProfile(
+    name="discovery",
+    goal="discovery",
+    selection="softmax",
+    cv="geometric",
+    tau1_steps=2,
+    tau2_steps=8,
+    max_trial=15,
+    sigma=0.1,
+    downstream=None,
+)
+
+# Quantitative sampling: longer segments, learned CV permitted, feeds weighted
+# ensemble by default. Numbers are starting points to be tuned per system.
+SAMPLING = RunProfile(
+    name="sampling",
+    goal="sampling",
+    selection="beam",
+    cv="learned",
+    tau1_steps=50,
+    tau2_steps=100,
+    max_trial=20,
+    sigma=0.2,
+    downstream="weighted_ensemble",
+)
+
+PROFILES = {p.name: p for p in (DISCOVERY, SAMPLING)}
+
+
+def get_profile(name: str) -> RunProfile:
+    try:
+        return PROFILES[str(name).lower()]
+    except KeyError:
+        raise KeyError(f"unknown run profile {name!r}; choose from {sorted(PROFILES)}")
+
+
+def resolve_profile(pg_cfg: dict) -> dict:
+    """Return ``pg_cfg`` with the named profile's defaults applied underneath.
+
+    The profile is taken from ``pg_cfg['profile']`` (or ``['goal']``).  Explicit,
+    non-null values in ``pg_cfg`` override the profile; if no profile is named the
+    config is returned unchanged, preserving current behaviour.
+    """
+
+    name = pg_cfg.get("profile") or pg_cfg.get("goal")
+    if name is None:
+        return dict(pg_cfg)
+    profile = get_profile(name)
+    defaults = {
+        "goal": profile.goal,
+        "selection": profile.selection,
+        "cv": profile.cv,
+        "tau1_steps": profile.tau1_steps,
+        "tau2_steps": profile.tau2_steps,
+        "max_trial": profile.max_trial,
+        "sigma": profile.sigma,
+        "downstream": profile.downstream,
+    }
+    explicit = {k: v for k, v in pg_cfg.items() if v is not None}
+    return {**defaults, **explicit}
+
+
+def check_learned_cv_segment_length(
+    tau1_steps: int,
+    tau2_steps: int,
+    timestep_ps: float,
+    *,
+    min_ps: float = 0.1,
+) -> bool:
+    """Warn (and return False) if segments look too short for a learned CV.
+
+    Returns True when the per-cycle MD time ``(tau1+tau2)*dt`` is at least
+    ``min_ps``.  This is advisory — the run still proceeds — to flag the
+    ultrashort-vs-learned-CV mismatch the discovery regime can introduce.
+    """
+
+    segment_ps = (int(tau1_steps) + int(tau2_steps)) * float(timestep_ps)
+    if segment_ps < float(min_ps):
+        logger.warning(
+            "Learned CV requested but per-cycle MD time is %.4f ps (< %.4f ps). "
+            "Ultrashort segments may not give a learnable CV; consider a longer "
+            "tau1/tau2 or the 'sampling' profile.",
+            segment_ps,
+            min_ps,
+        )
+        return False
+    return True

--- a/pathgennie/core/toy.py
+++ b/pathgennie/core/toy.py
@@ -1,0 +1,89 @@
+"""Toy 2-D Langevin engine on the Wolfe-Quapp potential.
+
+This is a pure-NumPy :class:`~pathgennie.core.engine.Engine` implementation used
+to exercise the *entire* driver (swarm -> selection -> runner -> convergence, and
+later beam/RRT policies) without any MD binary or GPU.  It also reproduces the
+paper's §2.4.1 Wolfe-Quapp benchmark: two minima connected by two saddle points,
+the canonical test for whether a sampler can find competing pathways.
+
+The potential (standard Wolfe-Quapp form)::
+
+    V(x, y) = x^4 + y^4 - 2 x^2 - 4 y^2 + x y + 0.3 x + 0.1 y
+
+is integrated with over-damped Langevin (Brownian) dynamics, so swarm diversity
+comes purely from the per-segment random seed — exactly the "selection bias on
+unbiased trajectories" PathGennie relies on.
+
+A *handle* is an integer id into an in-process state cache, mirroring the design
+of the OpenMM worker pool (state stays put; only ids move), which makes this a
+faithful proxy for testing ``clone_anchor`` / ``release`` semantics.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+import numpy as np
+
+__all__ = ["wolfe_quapp_potential", "wolfe_quapp_gradient", "ToyLangevinEngine"]
+
+
+def wolfe_quapp_potential(x: float, y: float) -> float:
+    return x**4 + y**4 - 2.0 * x**2 - 4.0 * y**2 + x * y + 0.3 * x + 0.1 * y
+
+
+def wolfe_quapp_gradient(pos: np.ndarray) -> np.ndarray:
+    x, y = float(pos[0]), float(pos[1])
+    gx = 4.0 * x**3 - 4.0 * x + y + 0.3
+    gy = 4.0 * y**3 - 8.0 * y + x + 0.1
+    return np.array([gx, gy], dtype=float)
+
+
+class ToyLangevinEngine:
+    """Over-damped Langevin dynamics on the Wolfe-Quapp surface."""
+
+    def __init__(self, *, dt: float = 0.002, kT: float = 1.0, gamma: float = 1.0):
+        self.dt = float(dt)
+        self.kT = float(kT)
+        self.gamma = float(gamma)
+        self._cache: Dict[int, np.ndarray] = {}
+        self._next_id = 0
+
+    # -- handle/state management -------------------------------------------------
+    def _store(self, pos: np.ndarray) -> int:
+        handle = self._next_id
+        self._next_id += 1
+        self._cache[handle] = np.asarray(pos, dtype=float).copy()
+        return handle
+
+    def create_state(self, position) -> int:
+        """Seed the cache with an initial 2-D position; returns its handle."""
+        return self._store(np.asarray(position, dtype=float)[:2])
+
+    def clone_anchor(self, handle: int) -> int:
+        return self._store(self._cache[handle])
+
+    def run_segment(
+        self,
+        handle: int,
+        n_steps: int,
+        *,
+        randomize_velocities: bool = True,
+        seed: int = 0,
+        device: Optional[int] = None,
+    ) -> int:
+        rng = np.random.default_rng(seed)
+        pos = self._cache[handle].copy()
+        diffusion = self.kT / self.gamma
+        noise_scale = np.sqrt(2.0 * diffusion * self.dt)
+        for _ in range(int(n_steps)):
+            force = -wolfe_quapp_gradient(pos)
+            pos = pos + (force / self.gamma) * self.dt + noise_scale * rng.standard_normal(2)
+        return self._store(pos)
+
+    def get_coords(self, handle: int) -> np.ndarray:
+        pos = self._cache[handle]
+        return np.array([[pos[0], pos[1], 0.0]], dtype=float)
+
+    def release(self, handle: int) -> None:
+        self._cache.pop(handle, None)

--- a/pathgennie/cv/__init__.py
+++ b/pathgennie/cv/__init__.py
@@ -1,0 +1,16 @@
+"""Data-driven collective variables for PathGennie.
+
+``features`` (pure NumPy) turns coordinates into invariant feature vectors; the
+optional ``spib`` module (requires PyTorch) learns a low-dimensional CV *and* a
+set of metastable states from accumulated swarm frames, exposed to the driver as
+an adaptive :class:`~pathgennie.core.progress.ProgressVariable`.
+"""
+
+from .features import Featurizer, contact_features, dihedral_features, pairwise_distances
+
+__all__ = [
+    "Featurizer",
+    "pairwise_distances",
+    "contact_features",
+    "dihedral_features",
+]

--- a/pathgennie/cv/features.py
+++ b/pathgennie/cv/features.py
@@ -1,0 +1,119 @@
+"""Coordinate featurization for data-driven CVs (pure NumPy).
+
+SPIB (and any learned CV) needs a fixed-length, roughly translation/rotation
+invariant description of a configuration.  This module provides the common
+choices used in the PathGennie examples — pairwise distances, soft contacts and
+dihedral sin/cos — plus a :class:`Featurizer` that composes them and applies
+online standardization, so the learned model sees well-scaled inputs.
+
+Everything here is NumPy-only so it has no heavy dependency and can run inside
+the MD worker; the learned model (PyTorch) consumes these features.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, List, Optional, Sequence
+
+import numpy as np
+
+__all__ = ["pairwise_distances", "contact_features", "dihedral_features", "Featurizer"]
+
+
+def pairwise_distances(coords: np.ndarray, pairs: Sequence[Sequence[int]]) -> np.ndarray:
+    """Euclidean distances for a list of atom-index pairs."""
+    coords = np.asarray(coords, dtype=float)
+    pairs = np.asarray(pairs, dtype=int)
+    diff = coords[pairs[:, 0]] - coords[pairs[:, 1]]
+    return np.linalg.norm(diff, axis=1)
+
+
+def contact_features(coords: np.ndarray, pairs: Sequence[Sequence[int]], r0: float = 8.0, n: int = 6, m: int = 12) -> np.ndarray:
+    """Smooth rational switching-function contacts (1 when close, 0 when far)."""
+    d = pairwise_distances(coords, pairs)
+    x = d / float(r0)
+    # Standard PLUMED-style switching function (1 - x^n) / (1 - x^m).
+    num = 1.0 - np.power(x, n)
+    den = 1.0 - np.power(x, m)
+    # Avoid 0/0 at x == 1 (limit is n/m).
+    out = np.where(np.abs(den) < 1e-9, n / m, num / den)
+    return out
+
+
+def dihedral_features(coords: np.ndarray, quads: Sequence[Sequence[int]]) -> np.ndarray:
+    """sin/cos of each dihedral (continuous, periodicity-safe)."""
+    coords = np.asarray(coords, dtype=float)
+    feats: List[float] = []
+    for a, b, c, d in quads:
+        p0, p1, p2, p3 = coords[a], coords[b], coords[c], coords[d]
+        b0 = -(p1 - p0)
+        b1 = p2 - p1
+        b2 = p3 - p2
+        b1n = b1 / (np.linalg.norm(b1) + 1e-12)
+        v = b0 - np.dot(b0, b1n) * b1n
+        w = b2 - np.dot(b2, b1n) * b1n
+        x = np.dot(v, w)
+        y = np.dot(np.cross(b1n, v), w)
+        angle = np.arctan2(y, x)
+        feats.extend([np.sin(angle), np.cos(angle)])
+    return np.asarray(feats, dtype=float)
+
+
+class Featurizer:
+    """Compose feature functions and apply (optional) online standardization.
+
+    Parameters
+    ----------
+    funcs:
+        List of callables ``f(coords) -> 1-D np.ndarray``.  If empty, the raw
+        flattened coordinates are used (useful for low-dimensional toy systems).
+    standardize:
+        If True, subtract mean / divide by std using statistics accumulated via
+        :meth:`fit` (Welford-style running moments).
+    """
+
+    def __init__(self, funcs: Optional[Sequence[Callable[[np.ndarray], np.ndarray]]] = None, *, standardize: bool = True):
+        self.funcs = list(funcs or [])
+        self.standardize = standardize
+        self._mean: Optional[np.ndarray] = None
+        self._m2: Optional[np.ndarray] = None
+        self._count = 0
+
+    def raw(self, coords: np.ndarray) -> np.ndarray:
+        coords = np.asarray(coords, dtype=float)
+        if not self.funcs:
+            return coords.ravel()
+        return np.concatenate([np.atleast_1d(np.asarray(f(coords), dtype=float).ravel()) for f in self.funcs])
+
+    def fit(self, coords_batch: Sequence[np.ndarray]) -> "Featurizer":
+        """Accumulate standardization statistics from a batch of configurations."""
+        for coords in coords_batch:
+            x = self.raw(coords)
+            self._count += 1
+            if self._mean is None:
+                self._mean = np.zeros_like(x)
+                self._m2 = np.zeros_like(x)
+            delta = x - self._mean
+            self._mean += delta / self._count
+            self._m2 += delta * (x - self._mean)
+        return self
+
+    @property
+    def std(self) -> Optional[np.ndarray]:
+        if self._m2 is None or self._count < 2:
+            return None
+        return np.sqrt(self._m2 / (self._count - 1)) + 1e-8
+
+    def transform(self, coords: np.ndarray) -> np.ndarray:
+        x = self.raw(coords)
+        if self.standardize and self._mean is not None and self.std is not None:
+            return (x - self._mean) / self.std
+        return x
+
+    def transform_batch(self, coords_batch: Sequence[np.ndarray]) -> np.ndarray:
+        return np.stack([self.transform(c) for c in coords_batch])
+
+    @property
+    def n_features(self) -> Optional[int]:
+        if self._mean is not None:
+            return int(self._mean.size)
+        return None

--- a/pathgennie/cv/spib.py
+++ b/pathgennie/cv/spib.py
@@ -1,0 +1,275 @@
+"""State Predictive Information Bottleneck (SPIB) data-driven CV.
+
+SPIB (Wang & Tiwary, *Nat. Commun.* 2021) learns a low-dimensional collective
+variable **and** a set of metastable states at the same time, directly from
+trajectory data, with no hand-crafted reaction coordinate.  It is the
+"self-contained, on-the-fly CV" called for in the PathGennie roadmap.
+
+Mechanism (predictive information bottleneck):
+
+* an encoder ``q(z|x)`` maps a featurized configuration to a Gaussian latent
+  ``z`` (the CV is its mean);
+* a classifier ``p(y|z)`` predicts, from ``z_t``, the *future* metastable-state
+  label ``y_{t+dt}``;
+* training minimises ``CE(p(y|z_t), y_{t+dt}) + beta * KL(q(z|x)||prior)`` — the
+  IB trade-off between predictiveness and compression;
+* state labels are refined self-consistently: after each training round every
+  frame is relabelled by ``argmax p(y|z)``, empty states are dropped, and the
+  number of metastable states **emerges** from the data.
+
+The learned encoder is exposed to the PathGennie driver through
+:class:`SPIBProgress`, an adaptive :class:`~pathgennie.core.progress.ProgressVariable`
+that bootstraps from a coarse geometric CV, buffers the frames the driver
+visits, retrains periodically, and then steers using the learned latent — the
+"iterative path-learning cycle".
+
+This module requires PyTorch; importing it without torch raises ImportError.
+The rest of :mod:`pathgennie.cv` (featurization) has no such dependency.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional, Sequence
+
+import numpy as np
+
+try:
+    import torch
+    import torch.nn as nn
+    import torch.nn.functional as F
+except ImportError as exc:  # pragma: no cover - exercised only without torch
+    raise ImportError("pathgennie.cv.spib requires PyTorch (`pip install torch`)") from exc
+
+from pathgennie.core.progress import ProgressVariable
+
+__all__ = ["SPIB", "train_spib", "SPIBResult", "kmeans_labels", "SPIBProgress"]
+
+
+# --------------------------------------------------------------------------- #
+# Lightweight k-means for label initialisation (avoids a scikit-learn dep).
+# --------------------------------------------------------------------------- #
+def kmeans_labels(x: np.ndarray, k: int, *, iters: int = 50, seed: int = 0) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    n = x.shape[0]
+    k = min(k, n)
+    centers = x[rng.choice(n, size=k, replace=False)].copy()
+    labels = np.zeros(n, dtype=int)
+    for _ in range(iters):
+        d = np.linalg.norm(x[:, None, :] - centers[None, :, :], axis=2)
+        new_labels = d.argmin(axis=1)
+        if np.array_equal(new_labels, labels):
+            break
+        labels = new_labels
+        for j in range(k):
+            members = x[labels == j]
+            if len(members):
+                centers[j] = members.mean(axis=0)
+    return labels
+
+
+class SPIB(nn.Module):
+    def __init__(self, n_features: int, n_states: int, latent_dim: int = 2, hidden: Sequence[int] = (64, 64)):
+        super().__init__()
+        layers: List[nn.Module] = []
+        prev = n_features
+        for h in hidden:
+            layers += [nn.Linear(prev, h), nn.ReLU()]
+            prev = h
+        self.encoder = nn.Sequential(*layers)
+        self.to_mean = nn.Linear(prev, latent_dim)
+        self.to_logvar = nn.Linear(prev, latent_dim)
+        self.classifier = nn.Sequential(nn.Linear(latent_dim, latent_dim), nn.ReLU(), nn.Linear(latent_dim, n_states))
+        self.latent_dim = latent_dim
+        self.n_states = n_states
+
+    def encode(self, x):
+        h = self.encoder(x)
+        return self.to_mean(h), self.to_logvar(h)
+
+    @staticmethod
+    def reparameterize(mean, logvar):
+        std = torch.exp(0.5 * logvar)
+        return mean + std * torch.randn_like(std)
+
+    def forward(self, x):
+        mean, logvar = self.encode(x)
+        z = self.reparameterize(mean, logvar)
+        return self.classifier(z), mean, logvar
+
+
+@dataclass
+class SPIBResult:
+    model: SPIB
+    labels: np.ndarray
+    n_states: int
+    feature_mean: np.ndarray = field(repr=False)
+    feature_std: np.ndarray = field(repr=False)
+
+
+def _kl_standard_normal(mean, logvar):
+    # KL(N(mean, var) || N(0, I)) per sample.
+    return -0.5 * torch.sum(1 + logvar - mean.pow(2) - logvar.exp(), dim=1)
+
+
+def train_spib(
+    features: np.ndarray,
+    *,
+    dt: int = 1,
+    n_states_init: int = 6,
+    latent_dim: int = 2,
+    beta: float = 1e-3,
+    epochs: int = 60,
+    lr: float = 1e-3,
+    n_refine: int = 6,
+    batch_size: int = 256,
+    seed: int = 0,
+) -> SPIBResult:
+    """Train SPIB on a time-ordered ``(n_frames, n_features)`` array.
+
+    Returns the trained model plus the converged per-frame state labels and the
+    emergent number of states.
+    """
+
+    torch.manual_seed(seed)
+    features = np.asarray(features, dtype=np.float64)
+    n = features.shape[0]
+    if n <= dt + 1:
+        raise ValueError("not enough frames for the requested lag time")
+
+    mean = features.mean(axis=0)
+    std = features.std(axis=0) + 1e-8
+    x_std = (features - mean) / std
+    x_all = torch.tensor(x_std, dtype=torch.float32)
+    x_t = x_all[:-dt]
+    fut_index = np.arange(dt, n)  # future frame index for each (t) sample
+
+    labels = kmeans_labels(x_std, n_states_init, seed=seed)
+    n_states = int(labels.max()) + 1
+
+    model: Optional[SPIB] = None
+    for _ in range(n_refine):
+        model = SPIB(features.shape[1], n_states, latent_dim=latent_dim)
+        opt = torch.optim.Adam(model.parameters(), lr=lr)
+        y_future = torch.tensor(labels[fut_index], dtype=torch.long)
+
+        idx = np.arange(x_t.shape[0])
+        for _epoch in range(epochs):
+            np.random.shuffle(idx)
+            for start in range(0, len(idx), batch_size):
+                batch = idx[start : start + batch_size]
+                xb = x_t[batch]
+                yb = y_future[batch]
+                logits, mu, logvar = model(xb)
+                loss = F.cross_entropy(logits, yb) + beta * _kl_standard_normal(mu, logvar).mean()
+                opt.zero_grad()
+                loss.backward()
+                opt.step()
+
+        # Self-consistent relabelling: each frame -> argmax p(y | mean(z)).
+        model.eval()
+        with torch.no_grad():
+            mu_all, _ = model.encode(x_all)
+            new_labels = model.classifier(mu_all).argmax(dim=1).numpy()
+
+        # Drop empty states and remap to a contiguous range.
+        used = np.unique(new_labels)
+        remap = {old: new for new, old in enumerate(used)}
+        new_labels = np.array([remap[v] for v in new_labels], dtype=int)
+        new_n_states = len(used)
+
+        converged = new_n_states == n_states and np.array_equal(new_labels, labels)
+        labels, n_states = new_labels, new_n_states
+        if converged or n_states <= 1:
+            break
+
+    assert model is not None
+    model.eval()
+    return SPIBResult(model=model, labels=labels, n_states=n_states, feature_mean=mean, feature_std=std)
+
+
+class SPIBProgress(ProgressVariable):
+    """Adaptive progress variable backed by an on-the-fly SPIB model.
+
+    Until enough frames are buffered the object delegates to a coarse
+    ``bootstrap`` progress variable; once trained it steers using the learned
+    latent (escape: maximise distance from the start latent; target: minimise
+    distance to the target latent).  ``observe`` is called by the driver each
+    cycle to grow the frame buffer and trigger periodic retraining.
+    """
+
+    def __init__(
+        self,
+        featurizer,
+        bootstrap: ProgressVariable,
+        *,
+        mode: str = "escape",
+        target_coords: Optional[np.ndarray] = None,
+        refresh_every: int = 50,
+        min_frames: int = 40,
+        dt: int = 1,
+        train_kwargs: Optional[dict] = None,
+    ):
+        if mode not in ("escape", "target"):
+            raise ValueError("mode must be 'escape' or 'target'")
+        if mode == "target" and target_coords is None:
+            raise ValueError("target_coords required for target mode")
+        self.featurizer = featurizer
+        self.bootstrap = bootstrap
+        self.mode = mode
+        self.target_coords = None if target_coords is None else np.asarray(target_coords, dtype=float)
+        self.refresh_every = int(refresh_every)
+        self.min_frames = int(min_frames)
+        self.dt = int(dt)
+        self.train_kwargs = dict(train_kwargs or {})
+        self._buffer: List[np.ndarray] = []
+        self.result: Optional[SPIBResult] = None
+        self._z_start: Optional[np.ndarray] = None
+        self._z_target: Optional[np.ndarray] = None
+        self._last_refresh = -1
+
+    # -- driver hook ---------------------------------------------------------
+    def observe(self, coords: np.ndarray, cycle: int) -> None:
+        self._buffer.append(np.asarray(coords, dtype=float).copy())
+        due = (cycle - self._last_refresh) >= self.refresh_every or self.result is None
+        if due and len(self._buffer) >= self.min_frames:
+            self._refresh()
+            self._last_refresh = cycle
+
+    def _encode(self, coords: np.ndarray) -> np.ndarray:
+        assert self.result is not None
+        x = (self.featurizer.raw(coords) - self.result.feature_mean) / self.result.feature_std
+        with torch.no_grad():
+            mu, _ = self.result.model.encode(torch.tensor(x, dtype=torch.float32).unsqueeze(0))
+        return mu.squeeze(0).numpy()
+
+    def _refresh(self) -> None:
+        features = np.stack([self.featurizer.raw(c) for c in self._buffer])
+        if features.shape[0] <= self.dt + 1:
+            return
+        self.result = train_spib(features, dt=self.dt, **self.train_kwargs)
+        self._z_start = self._encode(self._buffer[0])
+        if self.mode == "target":
+            self._z_target = self._encode(self.target_coords)
+
+    # -- ProgressVariable ----------------------------------------------------
+    def project(self, coords: np.ndarray) -> np.ndarray:
+        if self.result is None:
+            return np.asarray(self.bootstrap.project(coords), dtype=float)
+        return self._encode(coords)
+
+    def metric(self, cv: np.ndarray) -> float:
+        if self.result is None:
+            return float(self.bootstrap.metric(cv))
+        cv = np.asarray(cv, dtype=float)
+        if self.mode == "escape":
+            return float(np.linalg.norm(cv - self._z_start))
+        return float(-np.linalg.norm(cv - self._z_target))
+
+    @property
+    def n_states(self) -> Optional[int]:
+        return None if self.result is None else self.result.n_states
+
+    @property
+    def state_labels(self) -> Optional[np.ndarray]:
+        return None if self.result is None else self.result.labels

--- a/pathgennie/cv/spib.py
+++ b/pathgennie/cv/spib.py
@@ -132,6 +132,7 @@ def train_spib(
     """
 
     torch.manual_seed(seed)
+    rng = np.random.default_rng(seed)
     features = np.asarray(features, dtype=np.float64)
     n = features.shape[0]
     if n <= dt + 1:
@@ -155,7 +156,7 @@ def train_spib(
 
         idx = np.arange(x_t.shape[0])
         for _epoch in range(epochs):
-            np.random.shuffle(idx)
+            rng.shuffle(idx)
             for start in range(0, len(idx), batch_size):
                 batch = idx[start : start + batch_size]
                 xb = x_t[batch]

--- a/pathgennie/sampling/__init__.py
+++ b/pathgennie/sampling/__init__.py
@@ -15,6 +15,7 @@ from .base import (
     SamplingStage,
     build_path_ensemble,
 )
+from .opes import OPESStage, build_plumed_opes_input
 from .weighted_ensemble import GridBinner, Walker, WeightedEnsembleStage, resample
 
 __all__ = [
@@ -26,6 +27,8 @@ __all__ = [
     "GridBinner",
     "Walker",
     "resample",
+    "OPESStage",
+    "build_plumed_opes_input",
     "make_stage",
 ]
 
@@ -33,13 +36,12 @@ __all__ = [
 def make_stage(name: str, **cfg):
     """Construct an enhanced-sampling stage by ``downstream`` name.
 
-    Recognised: ``weighted_ensemble``.  ``opes`` is reserved for Phase 6b and
-    currently raises :class:`NotImplementedError`.
+    Recognised: ``weighted_ensemble`` (aliases ``we``/``wess``) and ``opes``.
     """
 
     key = str(name).lower()
     if key in ("weighted_ensemble", "we", "wess"):
         return WeightedEnsembleStage(**cfg)
     if key == "opes":
-        raise NotImplementedError("OPESStage is not implemented yet (Phase 6b)")
-    raise KeyError(f"unknown downstream stage {name!r}; choose from ['weighted_ensemble']")
+        return OPESStage(**cfg)
+    raise KeyError(f"unknown downstream stage {name!r}; choose from ['weighted_ensemble', 'opes']")

--- a/pathgennie/sampling/__init__.py
+++ b/pathgennie/sampling/__init__.py
@@ -9,6 +9,37 @@ OPES can be added as interchangeable implementations rather than bespoke
 scripts.
 """
 
-from .base import PathEnsemble, SamplingResult, SamplingStage
+from .base import (
+    PathEnsemble,
+    SamplingResult,
+    SamplingStage,
+    build_path_ensemble,
+)
+from .weighted_ensemble import GridBinner, Walker, WeightedEnsembleStage, resample
 
-__all__ = ["PathEnsemble", "SamplingResult", "SamplingStage"]
+__all__ = [
+    "PathEnsemble",
+    "SamplingResult",
+    "SamplingStage",
+    "build_path_ensemble",
+    "WeightedEnsembleStage",
+    "GridBinner",
+    "Walker",
+    "resample",
+    "make_stage",
+]
+
+
+def make_stage(name: str, **cfg):
+    """Construct an enhanced-sampling stage by ``downstream`` name.
+
+    Recognised: ``weighted_ensemble``.  ``opes`` is reserved for Phase 6b and
+    currently raises :class:`NotImplementedError`.
+    """
+
+    key = str(name).lower()
+    if key in ("weighted_ensemble", "we", "wess"):
+        return WeightedEnsembleStage(**cfg)
+    if key == "opes":
+        raise NotImplementedError("OPESStage is not implemented yet (Phase 6b)")
+    raise KeyError(f"unknown downstream stage {name!r}; choose from ['weighted_ensemble']")

--- a/pathgennie/sampling/__init__.py
+++ b/pathgennie/sampling/__init__.py
@@ -16,6 +16,13 @@ from .base import (
     build_path_ensemble,
 )
 from .opes import OPESStage, build_plumed_opes_input
+from .path_sampling import (
+    CVRangeState,
+    PathSamplingStage,
+    extract_transition_path,
+    prepare_ops_seed,
+    tis_interfaces,
+)
 from .weighted_ensemble import GridBinner, Walker, WeightedEnsembleStage, resample
 
 __all__ = [
@@ -29,6 +36,11 @@ __all__ = [
     "resample",
     "OPESStage",
     "build_plumed_opes_input",
+    "PathSamplingStage",
+    "CVRangeState",
+    "extract_transition_path",
+    "prepare_ops_seed",
+    "tis_interfaces",
     "make_stage",
 ]
 
@@ -36,7 +48,8 @@ __all__ = [
 def make_stage(name: str, **cfg):
     """Construct an enhanced-sampling stage by ``downstream`` name.
 
-    Recognised: ``weighted_ensemble`` (aliases ``we``/``wess``) and ``opes``.
+    Recognised: ``weighted_ensemble`` (aliases ``we``/``wess``), ``opes``, and
+    ``tps``/``tis`` (OpenPathSampling, for kinetics).
     """
 
     key = str(name).lower()
@@ -44,4 +57,9 @@ def make_stage(name: str, **cfg):
         return WeightedEnsembleStage(**cfg)
     if key == "opes":
         return OPESStage(**cfg)
-    raise KeyError(f"unknown downstream stage {name!r}; choose from ['weighted_ensemble', 'opes']")
+    if key in ("tps", "tis"):
+        return PathSamplingStage(mode=key, **cfg)
+    raise KeyError(
+        f"unknown downstream stage {name!r}; choose from "
+        "['weighted_ensemble', 'opes', 'tps', 'tis']"
+    )

--- a/pathgennie/sampling/__init__.py
+++ b/pathgennie/sampling/__init__.py
@@ -1,0 +1,14 @@
+"""Enhanced-sampling stages built on top of PathGennie output.
+
+PathGennie generates candidate reactive paths cheaply; turning those into
+free-energy surfaces or rate constants is the job of a downstream
+*enhanced-sampling stage*.  This package defines the consistent contract those
+stages share — :class:`PathEnsemble` (what a PathGennie run hands downstream) and
+:class:`SamplingStage` (how a stage consumes it) — so weighted ensemble (WE) and
+OPES can be added as interchangeable implementations rather than bespoke
+scripts.
+"""
+
+from .base import PathEnsemble, SamplingResult, SamplingStage
+
+__all__ = ["PathEnsemble", "SamplingResult", "SamplingStage"]

--- a/pathgennie/sampling/base.py
+++ b/pathgennie/sampling/base.py
@@ -1,0 +1,66 @@
+"""Shared data + protocol for PathGennie enhanced-sampling stages.
+
+A :class:`PathEnsemble` is the hand-off from a PathGennie run to a downstream
+stage.  It carries the reactive path frames plus the extra information that makes
+the path a good *informed seed*: the CV trajectory, optional per-frame metastable
+state labels (e.g. from SPIB, for binning / defining WE bins or OPES states), and
+optional engine handles so a stage can restart MD from any frame.
+
+A :class:`SamplingStage` consumes a :class:`PathEnsemble` (and an engine) and
+returns a :class:`SamplingResult`.  Concrete stages — weighted ensemble (the
+paper's "path-informed WESS") and OPES for free-energy surfaces — implement this
+single ``run`` method, so they are interchangeable and configured the same way
+(``pathgennie.downstream: weighted_ensemble | opes``).
+
+This module is intentionally implementation-free: it fixes the integration
+contract so the WE and OPES stages can be added consistently later.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, List, Optional, Protocol, runtime_checkable
+
+import numpy as np
+
+__all__ = ["PathEnsemble", "SamplingResult", "SamplingStage"]
+
+
+@dataclass
+class PathEnsemble:
+    """Output of a PathGennie run, usable as seeds for enhanced sampling."""
+
+    frames: np.ndarray                                   # (n_frames, n_atoms, 3) Angstrom
+    metrics: np.ndarray                                  # per-cycle progress metric
+    cv_trajectory: Optional[np.ndarray] = None           # (n_frames, n_cv)
+    state_labels: Optional[np.ndarray] = None            # (n_frames,) metastable-state ids
+    handles: List[Any] = field(default_factory=list)     # engine handles for restartable seeds
+    metadata: dict = field(default_factory=dict)
+
+    @property
+    def n_frames(self) -> int:
+        return int(self.frames.shape[0]) if self.frames.ndim == 3 else 0
+
+
+@dataclass
+class SamplingResult:
+    """Result of an enhanced-sampling stage (free energies / rates / weights)."""
+
+    free_energy: Optional[np.ndarray] = None
+    rate_constants: Optional[dict] = None
+    weights: Optional[np.ndarray] = None
+    metadata: dict = field(default_factory=dict)
+
+
+@runtime_checkable
+class SamplingStage(Protocol):
+    """Consume a PathGennie :class:`PathEnsemble` and produce a result.
+
+    Implementations (planned): ``WeightedEnsembleStage`` (path-informed WE for
+    rate constants) and ``OPESStage`` (free-energy surfaces).  ``engine`` is a
+    :class:`pathgennie.core.engine.Engine` so the stage can launch further MD
+    from the ensemble's seed frames.
+    """
+
+    def run(self, ensemble: PathEnsemble, engine: Any, **kwargs: Any) -> SamplingResult:
+        ...

--- a/pathgennie/sampling/base.py
+++ b/pathgennie/sampling/base.py
@@ -23,7 +23,7 @@ from typing import Any, List, Optional, Protocol, runtime_checkable
 
 import numpy as np
 
-__all__ = ["PathEnsemble", "SamplingResult", "SamplingStage"]
+__all__ = ["PathEnsemble", "SamplingResult", "SamplingStage", "build_path_ensemble"]
 
 
 @dataclass
@@ -64,3 +64,33 @@ class SamplingStage(Protocol):
 
     def run(self, ensemble: PathEnsemble, engine: Any, **kwargs: Any) -> SamplingResult:
         ...
+
+
+def build_path_ensemble(
+    frames: np.ndarray,
+    metrics: np.ndarray,
+    *,
+    handles: Optional[List[Any]] = None,
+    cv_fn: Optional[Any] = None,
+    state_labels: Optional[np.ndarray] = None,
+    metadata: Optional[dict] = None,
+) -> PathEnsemble:
+    """Assemble a :class:`PathEnsemble` from a driver run's outputs.
+
+    ``handles`` are the restartable seed handles from ``driver.run(...,
+    collect_seeds=True)``.  If ``cv_fn`` is given it is mapped over ``frames`` to
+    fill ``cv_trajectory`` (each frame is an ``(n_atoms, 3)`` array).
+    """
+
+    frames = np.asarray(frames, dtype=float)
+    cv_trajectory = None
+    if cv_fn is not None and frames.ndim == 3 and frames.shape[0] > 0:
+        cv_trajectory = np.array([np.atleast_1d(np.asarray(cv_fn(f), dtype=float)) for f in frames])
+    return PathEnsemble(
+        frames=frames,
+        metrics=np.asarray(metrics, dtype=float),
+        cv_trajectory=cv_trajectory,
+        state_labels=None if state_labels is None else np.asarray(state_labels),
+        handles=list(handles) if handles is not None else [],
+        metadata=dict(metadata or {}),
+    )

--- a/pathgennie/sampling/opes.py
+++ b/pathgennie/sampling/opes.py
@@ -1,0 +1,280 @@
+"""OPES free-energy stage, with a PLUMED interface and a verifiable core.
+
+OPES (On-the-fly Probability Enhanced Sampling; Invernizzi & Parrinello, 2020)
+deposits an adaptive bias along a CV so the system samples a flatter
+distribution, from which the free-energy surface (FES) is recovered by
+reweighting.  In production this is done by **PLUMED** (https://www.plumed.org/)
+patched into the MD engine; PathGennie supplies the CV definition, the OPES
+parameters, and the seed configurations from a :class:`PathEnsemble`.
+
+This module provides two layers:
+
+* :func:`build_plumed_opes_input` + :class:`OPESStage` (``mode="plumed"``) — the
+  production path.  It writes a ``plumed.dat`` with an ``OPES_METAD`` action and
+  drives a PLUMED-capable engine (one exposing ``run_plumed``); if the engine
+  cannot run PLUMED it raises with guidance.  This is the interface the MD
+  backends plug into once PLUMED is available.
+* :class:`OPESBias` + :class:`OPESSimulation` + ``OPESStage(mode="toy")`` — a
+  dependency-free implementation of the OPES bias and reweighting on an analytic
+  potential (e.g. the toy Wolfe-Quapp surface), so the *algorithm* is verifiable
+  in CI without an MD binary.  The bias-update and reweighting maths are identical
+  to the production path; only the propagator differs.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, List, Optional, Sequence
+
+import numpy as np
+
+from .base import PathEnsemble, SamplingResult
+
+__all__ = ["build_plumed_opes_input", "OPESBias", "OPESSimulation", "OPESStage"]
+
+
+# --------------------------------------------------------------------------- #
+# PLUMED interface (production path)
+# --------------------------------------------------------------------------- #
+def build_plumed_opes_input(
+    cv_definitions: Sequence[str],
+    arg_names: Sequence[str],
+    *,
+    pace: int = 500,
+    barrier: float = 40.0,
+    temp: float = 300.0,
+    sigma: Optional[Sequence[float]] = None,
+    grid_min: Optional[Sequence[float]] = None,
+    grid_max: Optional[Sequence[float]] = None,
+    colvar_file: str = "COLVAR",
+    state_file: str = "STATE",
+    stride: int = 100,
+) -> str:
+    """Return a ``plumed.dat`` driving ``OPES_METAD`` along the given CV(s).
+
+    ``cv_definitions`` are raw PLUMED action lines (e.g.
+    ``"phi: TORSION ATOMS=5,7,9,15"``); ``arg_names`` are the labels OPES biases
+    (e.g. ``["phi", "psi"]``). ``barrier`` is the OPES barrier parameter (kJ/mol),
+    ``temp`` the temperature (K).
+    """
+
+    lines: List[str] = ["# PathGennie-generated OPES input", "UNITS LENGTH=A"]
+    lines.extend(str(line) for line in cv_definitions)
+
+    opes = [
+        "OPES_METAD ...",
+        "  LABEL=opes",
+        f"  ARG={','.join(arg_names)}",
+        f"  PACE={int(pace)}",
+        f"  BARRIER={float(barrier)}",
+        f"  TEMP={float(temp)}",
+        f"  STATE_WFILE={state_file}",
+    ]
+    if sigma is not None:
+        opes.append(f"  SIGMA={','.join(str(float(s)) for s in sigma)}")
+    if grid_min is not None and grid_max is not None:
+        opes.append(f"  GRID_MIN={','.join(str(float(g)) for g in grid_min)}")
+        opes.append(f"  GRID_MAX={','.join(str(float(g)) for g in grid_max)}")
+    opes.append("...")
+    lines.extend(opes)
+
+    lines.append(
+        f"PRINT ARG={','.join(arg_names)},opes.bias STRIDE={int(stride)} FILE={colvar_file}"
+    )
+    return "\n".join(lines) + "\n"
+
+
+# --------------------------------------------------------------------------- #
+# Verifiable OPES core (toy path)
+# --------------------------------------------------------------------------- #
+class OPESBias:
+    """Adaptive well-tempered kernel bias along a 1-D CV (OPES_METAD core)."""
+
+    def __init__(self, *, kT: float, gamma: float = 10.0, sigma: float = 0.1, barrier: float = 10.0):
+        self.kT = float(kT)
+        self.beta = 1.0 / self.kT
+        self.gamma = float(gamma)
+        self.sigma = float(sigma)
+        self.barrier = float(barrier)
+        self.prefactor = 1.0 - 1.0 / self.gamma
+        # Floor so the deepest bias well is ~ -barrier (in energy units).
+        self._log_floor = -self.barrier / (self.prefactor * self.kT)
+        self.centers: List[float] = []
+        self.heights: List[float] = []
+
+    def _prob(self, s: float) -> float:
+        if not self.centers:
+            return 0.0
+        c = np.asarray(self.centers)
+        h = np.asarray(self.heights)
+        k = np.exp(-0.5 * ((s - c) / self.sigma) ** 2)
+        return float((h * k).sum() / h.sum())
+
+    def bias(self, s: float) -> float:
+        p = self._prob(s)
+        log_p = np.log(p) if p > 0 else self._log_floor
+        log_p = max(log_p, self._log_floor)
+        return self.prefactor * self.kT * log_p
+
+    def grad(self, s: float, ds: float = 1e-3) -> float:
+        return (self.bias(s + ds) - self.bias(s - ds)) / (2.0 * ds)
+
+    def update(self, s: float) -> None:
+        height = np.exp(self.beta * self.bias(s))  # well-tempered down-scaling
+        self.centers.append(float(s))
+        self.heights.append(float(height))
+
+
+class OPESSimulation:
+    """Biased over-damped Langevin on an analytic potential (toy verification)."""
+
+    def __init__(
+        self,
+        grad_fn: Callable[[np.ndarray], np.ndarray],
+        *,
+        cv_axis: int = 1,
+        kT: float = 1.0,
+        gamma_friction: float = 1.0,
+        dt: float = 0.005,
+        pace: int = 50,
+        bias: Optional[OPESBias] = None,
+        seed: int = 0,
+    ):
+        self.grad_fn = grad_fn
+        self.cv_axis = int(cv_axis)
+        self.kT = float(kT)
+        self.gamma_friction = float(gamma_friction)
+        self.dt = float(dt)
+        self.pace = int(pace)
+        self.bias = bias or OPESBias(kT=kT)
+        self.rng = np.random.default_rng(seed)
+
+    def run(self, pos0: np.ndarray, n_steps: int, *, record_stride: int = 1):
+        pos = np.asarray(pos0, dtype=float).copy()
+        noise_scale = np.sqrt(2.0 * (self.kT / self.gamma_friction) * self.dt)
+        samples: List[float] = []
+        for step in range(int(n_steps)):
+            s = pos[self.cv_axis]
+            force = -self.grad_fn(pos)
+            force[self.cv_axis] += -self.bias.grad(s)
+            pos = pos + (force / self.gamma_friction) * self.dt + noise_scale * self.rng.standard_normal(pos.shape)
+            if step % self.pace == 0:
+                self.bias.update(pos[self.cv_axis])
+            if step % record_stride == 0:
+                samples.append(float(pos[self.cv_axis]))
+        return np.asarray(samples)
+
+    def fes(self, samples: np.ndarray, grid: np.ndarray) -> np.ndarray:
+        """Reweighted free energy on ``grid`` using the converged bias."""
+        samples = np.asarray(samples)
+        weights = np.exp(self.bias.beta * np.array([self.bias.bias(s) for s in samples]))
+        edges = np.concatenate([
+            [grid[0] - 0.5 * (grid[1] - grid[0])],
+            0.5 * (grid[:-1] + grid[1:]),
+            [grid[-1] + 0.5 * (grid[-1] - grid[-2])],
+        ])
+        hist, _ = np.histogram(samples, bins=edges, weights=weights)
+        prob = hist / hist.sum() if hist.sum() > 0 else hist
+        with np.errstate(divide="ignore"):
+            fe = -self.kT * np.log(prob)
+        finite = fe[np.isfinite(fe)]
+        if finite.size:
+            fe = fe - finite.min()
+        return fe
+
+
+class OPESStage:
+    """OPES free-energy stage (implements the ``SamplingStage`` contract).
+
+    ``mode='plumed'`` (default) generates a PLUMED ``OPES_METAD`` input and drives
+    a PLUMED-capable engine (``engine.run_plumed(plumed_input, ensemble, **cfg)``).
+    ``mode='toy'`` runs the verifiable analytic-potential core and requires
+    ``potential_grad`` (a ``pos -> grad`` callable) and ``cv_axis``.
+    """
+
+    def __init__(
+        self,
+        cv_fn: Optional[Callable[[np.ndarray], float]] = None,
+        *,
+        mode: str = "plumed",
+        # toy-mode parameters
+        potential_grad: Optional[Callable[[np.ndarray], np.ndarray]] = None,
+        cv_axis: int = 1,
+        grid: Optional[Sequence[float]] = None,
+        n_steps: int = 20000,
+        dt: float = 0.005,
+        pace: int = 50,
+        gamma: float = 10.0,
+        sigma: float = 0.15,
+        barrier: float = 10.0,
+        kT: float = 1.0,
+        seed: int = 0,
+        # plumed-mode parameters
+        plumed_cv_definitions: Optional[Sequence[str]] = None,
+        plumed_arg_names: Optional[Sequence[str]] = None,
+        plumed_kwargs: Optional[dict] = None,
+    ):
+        if mode not in ("plumed", "toy"):
+            raise ValueError("mode must be 'plumed' or 'toy'")
+        self.cv_fn = cv_fn
+        self.mode = mode
+        self.potential_grad = potential_grad
+        self.cv_axis = int(cv_axis)
+        self.grid = None if grid is None else np.asarray(grid, dtype=float)
+        self.n_steps = int(n_steps)
+        self.dt = float(dt)
+        self.pace = int(pace)
+        self.gamma = float(gamma)
+        self.sigma = float(sigma)
+        self.barrier = float(barrier)
+        self.kT = float(kT)
+        self.seed = int(seed)
+        self.plumed_cv_definitions = plumed_cv_definitions
+        self.plumed_arg_names = plumed_arg_names
+        self.plumed_kwargs = dict(plumed_kwargs or {})
+
+    def run(self, ensemble: PathEnsemble, engine, **_: object) -> SamplingResult:
+        if self.mode == "plumed":
+            return self._run_plumed(ensemble, engine)
+        return self._run_toy(ensemble)
+
+    def _run_plumed(self, ensemble: PathEnsemble, engine) -> SamplingResult:
+        if not self.plumed_cv_definitions or not self.plumed_arg_names:
+            raise ValueError("plumed mode requires plumed_cv_definitions and plumed_arg_names")
+        plumed_input = build_plumed_opes_input(
+            self.plumed_cv_definitions, self.plumed_arg_names,
+            pace=self.pace, barrier=self.barrier, **self.plumed_kwargs,
+        )
+        runner = getattr(engine, "run_plumed", None)
+        if runner is None:
+            raise NotImplementedError(
+                "OPESStage(mode='plumed') needs a PLUMED-capable engine exposing "
+                "run_plumed(plumed_input, ensemble, **cfg). Patch the MD backend "
+                "with PLUMED, or use mode='toy' with an analytic potential_grad."
+            )
+        return runner(plumed_input, ensemble, **self.plumed_kwargs)
+
+    def _run_toy(self, ensemble: PathEnsemble) -> SamplingResult:
+        if self.potential_grad is None:
+            raise ValueError("toy mode requires potential_grad (pos -> grad)")
+        # Toy potentials are 2-D; engine coords are (n_atoms, 3). Use the first
+        # atom's leading dims up to the gradient's dimensionality.
+        pos0 = np.asarray(ensemble.frames[0][0, :], dtype=float)
+        grad_dim = int(np.asarray(self.potential_grad(pos0[:2])).size)
+        pos0 = pos0[:grad_dim]
+        if self.grid is not None:
+            grid = self.grid
+        else:
+            vals = ensemble.cv_trajectory[:, 0] if ensemble.cv_trajectory is not None else pos0[self.cv_axis]
+            lo, hi = float(np.min(vals)) - 0.5, float(np.max(vals)) + 0.5
+            grid = np.linspace(lo, hi, 40)
+        bias = OPESBias(kT=self.kT, gamma=self.gamma, sigma=self.sigma, barrier=self.barrier)
+        sim = OPESSimulation(
+            self.potential_grad, cv_axis=self.cv_axis, kT=self.kT,
+            dt=self.dt, pace=self.pace, bias=bias, seed=self.seed,
+        )
+        samples = sim.run(pos0, self.n_steps)
+        fe = sim.fes(samples, grid)
+        return SamplingResult(
+            free_energy=fe,
+            metadata={"grid": grid, "n_kernels": len(bias.centers), "n_samples": samples.size},
+        )

--- a/pathgennie/sampling/path_sampling.py
+++ b/pathgennie/sampling/path_sampling.py
@@ -1,0 +1,311 @@
+"""OpenPathSampling (OPS) bridge: TPS / TIS on PathGennie seed pathways.
+
+PathGennie discovers reactive A->B pathways cheaply. Transition Path Sampling
+(TPS) and Transition Interface Sampling (TIS), as implemented by
+**OpenPathSampling** (https://openpathsampling.org/), need an *initial reactive
+trajectory* to bootstrap — exactly what a PathGennie run produces. This module is
+the bridge, an alternative to Weighted Ensemble for computing kinetics.
+
+Two layers, mirroring the OPES module:
+
+* **Dependency-free, CI-verified prep** — turn a discovered
+  :class:`~pathgennie.sampling.base.PathEnsemble` into an OPS-ready seed: define
+  states as CV ranges (:class:`CVRangeState`), label frames, extract the minimal
+  reactive sub-path (:func:`extract_transition_path`), and lay out TIS interfaces
+  (:func:`tis_interfaces`). This is pure NumPy and always available.
+* **OPS-dependent stage** — :class:`PathSamplingStage` builds the OPS CV, state
+  volumes, TPS/TIS network and move scheme, seeds them with the prepared
+  trajectory, runs ``PathSampling``, and returns kinetics in a
+  :class:`~pathgennie.sampling.base.SamplingResult`. It lazily imports
+  ``openpathsampling`` and requires an OPS-compatible engine (OPS propagates with
+  its *own* engine, e.g. ``openpathsampling.engines.openmm``); without either it
+  raises with guidance. Install via the ``pathsampling`` extra.
+
+Targets the OpenPathSampling 1.x API.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, List, Optional, Sequence, Tuple
+
+import numpy as np
+
+from .base import PathEnsemble, SamplingResult
+
+__all__ = [
+    "CVRangeState",
+    "label_frames",
+    "extract_transition_path",
+    "is_reactive",
+    "tis_interfaces",
+    "prepare_ops_seed",
+    "PathSamplingStage",
+]
+
+# Frame state labels.
+NO_STATE = -1
+STATE_A = 0
+STATE_B = 1
+
+
+@dataclass
+class CVRangeState:
+    """A state defined as a closed interval ``[lo, hi]`` of a scalar CV."""
+
+    name: str
+    lo: float
+    hi: float
+
+    def contains(self, cv_value: float) -> bool:
+        return self.lo <= float(cv_value) <= self.hi
+
+
+# --------------------------------------------------------------------------- #
+# Dependency-free seed preparation (always available, unit-tested)
+# --------------------------------------------------------------------------- #
+def label_frames(
+    frames: np.ndarray,
+    cv_fn: Callable[[np.ndarray], float],
+    state_a: CVRangeState,
+    state_b: CVRangeState,
+) -> np.ndarray:
+    """Label each frame ``STATE_A`` / ``STATE_B`` / ``NO_STATE`` by its CV."""
+    labels = np.full(len(frames), NO_STATE, dtype=int)
+    for i, frame in enumerate(frames):
+        s = float(cv_fn(frame))
+        if state_a.contains(s):
+            labels[i] = STATE_A
+        elif state_b.contains(s):
+            labels[i] = STATE_B
+    return labels
+
+
+def extract_transition_path(
+    frames: np.ndarray,
+    cv_fn: Callable[[np.ndarray], float],
+    state_a: CVRangeState,
+    state_b: CVRangeState,
+) -> Optional[Tuple[int, int]]:
+    """Return ``(start, end)`` indices of the minimal A->B reactive sub-path.
+
+    The seed for TPS/TIS is the segment from the *last* frame in A before the
+    *first* subsequent frame in B. Returns ``None`` if the path is not reactive
+    (never reaches B, or never visits A beforehand).
+    """
+    labels = label_frames(frames, cv_fn, state_a, state_b)
+    b_indices = np.where(labels == STATE_B)[0]
+    if b_indices.size == 0:
+        return None
+    b_first = int(b_indices[0])
+    a_before = np.where(labels[:b_first] == STATE_A)[0]
+    if a_before.size == 0:
+        return None
+    a_last = int(a_before[-1])
+    return a_last, b_first
+
+
+def is_reactive(
+    frames: np.ndarray,
+    cv_fn: Callable[[np.ndarray], float],
+    state_a: CVRangeState,
+    state_b: CVRangeState,
+) -> bool:
+    return extract_transition_path(frames, cv_fn, state_a, state_b) is not None
+
+
+def tis_interfaces(lambda0: float, lambdaN: float, n_interfaces: int, *, spacing: str = "linear") -> np.ndarray:
+    """Lay out ``n_interfaces`` TIS interface values in ``[lambda0, lambdaN]``.
+
+    ``spacing='linear'`` (uniform) or ``'exp'`` (denser near ``lambda0``, where
+    crossing probabilities change fastest). Always strictly increasing.
+    """
+    if n_interfaces < 1:
+        raise ValueError("n_interfaces must be >= 1")
+    if lambdaN <= lambda0:
+        raise ValueError("lambdaN must be > lambda0")
+    if n_interfaces == 1:
+        return np.array([float(lambda0)])
+    if spacing == "linear":
+        return np.linspace(lambda0, lambdaN, n_interfaces)
+    if spacing == "exp":
+        frac = (np.expm1(np.linspace(0.0, 1.0, n_interfaces))) / np.expm1(1.0)
+        return lambda0 + (lambdaN - lambda0) * frac
+    raise ValueError("spacing must be 'linear' or 'exp'")
+
+
+def prepare_ops_seed(
+    ensemble: PathEnsemble,
+    cv_fn: Callable[[np.ndarray], float],
+    state_a: CVRangeState,
+    state_b: CVRangeState,
+    *,
+    interfaces: Optional[Sequence[float]] = None,
+) -> dict:
+    """PathGennie-side preparation for OPS: validate and slice the seed path.
+
+    Returns a dict with the reactive sub-path indices/frames, per-frame labels,
+    the CV trajectory, and the (optional) interface set — everything OPS needs to
+    be seeded, computed without importing OPS.
+    """
+    frames = np.asarray(ensemble.frames, dtype=float)
+    labels = label_frames(frames, cv_fn, state_a, state_b)
+    span = extract_transition_path(frames, cv_fn, state_a, state_b)
+    seed = None
+    if span is not None:
+        start, end = span
+        seed = frames[start : end + 1]
+    return {
+        "reactive": span is not None,
+        "span": span,
+        "seed_frames": seed,
+        "labels": labels,
+        "cv_trajectory": np.array([float(cv_fn(f)) for f in frames]),
+        "interfaces": None if interfaces is None else np.asarray(interfaces, dtype=float),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# OPS-dependent stage (lazy import)
+# --------------------------------------------------------------------------- #
+def _import_ops():
+    try:
+        import openpathsampling as paths  # noqa: F401
+    except ImportError as exc:  # pragma: no cover - exercised when OPS absent
+        raise ImportError(
+            "TPS/TIS requires OpenPathSampling. Install it with the "
+            "'pathsampling' extra (pip install pathgennie[pathsampling]) or "
+            "`pip install openpathsampling`, and pass an OPS-compatible engine "
+            "(OPS propagates with its own engine, e.g. "
+            "openpathsampling.engines.openmm)."
+        ) from exc
+    return paths
+
+
+class PathSamplingStage:
+    """Run TPS or TIS on a PathGennie seed path via OpenPathSampling.
+
+    Parameters
+    ----------
+    cv_fn:
+        ``coords -> scalar`` progress coordinate (reuse the discovery projection).
+    state_a, state_b:
+        ``(lo, hi)`` CV intervals (or :class:`CVRangeState`) defining the states.
+    mode:
+        ``"tps"`` (fixed-length / flexible TPS) or ``"tis"`` (interface sampling
+        for rate constants).
+    interfaces:
+        TIS interface values (required for ``mode="tis"``); see
+        :func:`tis_interfaces`.
+    ops_engine:
+        An OpenPathSampling engine used to propagate shooting moves. Required to
+        actually run; OPS uses its own engine, not PathGennie's swarm engine.
+    n_steps:
+        Number of Monte-Carlo path moves.
+    storage_path:
+        Optional OPS ``.nc`` storage file.
+    """
+
+    def __init__(
+        self,
+        cv_fn: Callable[[np.ndarray], float],
+        *,
+        state_a,
+        state_b,
+        mode: str = "tps",
+        interfaces: Optional[Sequence[float]] = None,
+        ops_engine=None,
+        n_steps: int = 1000,
+        storage_path: Optional[str] = None,
+        cv_name: str = "pathgennie_cv",
+    ):
+        if mode not in ("tps", "tis"):
+            raise ValueError("mode must be 'tps' or 'tis'")
+        self.cv_fn = cv_fn
+        self.state_a = state_a if isinstance(state_a, CVRangeState) else CVRangeState("A", float(state_a[0]), float(state_a[1]))
+        self.state_b = state_b if isinstance(state_b, CVRangeState) else CVRangeState("B", float(state_b[0]), float(state_b[1]))
+        self.mode = mode
+        self.interfaces = None if interfaces is None else list(interfaces)
+        self.ops_engine = ops_engine
+        self.n_steps = int(n_steps)
+        self.storage_path = storage_path
+        self.cv_name = cv_name
+        if mode == "tis" and not self.interfaces:
+            raise ValueError("mode='tis' requires interfaces (see tis_interfaces)")
+
+    def run(self, ensemble: PathEnsemble, engine=None, **_: object) -> SamplingResult:
+        paths = _import_ops()
+        if self.ops_engine is None:
+            raise ValueError(
+                "PathSamplingStage needs an OpenPathSampling engine (ops_engine=). "
+                "OPS propagates shooting moves with its own engine; build one (e.g. "
+                "openpathsampling.engines.openmm.Engine) and pass it in."
+            )
+
+        # PathGennie-side validation/slicing (no OPS needed).
+        seed = prepare_ops_seed(ensemble, self.cv_fn, self.state_a, self.state_b, interfaces=self.interfaces)
+        if not seed["reactive"]:
+            raise ValueError(
+                "The PathEnsemble is not a reactive A->B path under the given "
+                "state definitions; cannot seed TPS/TIS. Check state_a/state_b "
+                "ranges and the cv_fn."
+            )
+
+        # Build the OPS objects and run.
+        cv = paths.CoordinateFunctionCV(self.cv_name, lambda snap: self.cv_fn(self._snapshot_coords(snap)))
+        vol_a = paths.CVDefinedVolume(cv, self.state_a.lo, self.state_a.hi).named(self.state_a.name)
+        vol_b = paths.CVDefinedVolume(cv, self.state_b.lo, self.state_b.hi).named(self.state_b.name)
+
+        init_traj = self._to_ops_trajectory(paths, seed["seed_frames"])
+
+        if self.mode == "tps":
+            network = paths.TPSNetwork(vol_a, vol_b)
+        else:
+            interface_set = paths.VolumeInterfaceSet(cv, float("-inf"), self.interfaces)
+            network = paths.MISTISNetwork([(vol_a, interface_set, vol_b)])
+
+        scheme = paths.OneWayShootingMoveScheme(network, engine=self.ops_engine)
+        init_conditions = scheme.initial_conditions_from_trajectories(init_traj)
+
+        storage = paths.Storage(self.storage_path, "w") if self.storage_path else None
+        sampler = paths.PathSampling(storage=storage, move_scheme=scheme, sample_set=init_conditions)
+        sampler.run(self.n_steps)
+        if storage is not None:
+            storage.close()
+
+        return self._analyze(paths, sampler, network)
+
+    # -- helpers (OPS-version specific; documented integration points) -------
+    @staticmethod
+    def _snapshot_coords(snapshot) -> np.ndarray:
+        """OPS snapshot -> (n_atoms, 3) Angstrom array for the user's cv_fn."""
+        xyz = np.asarray(snapshot.xyz, dtype=float)  # OPS xyz is in nm
+        return xyz * 10.0
+
+    def _to_ops_trajectory(self, paths, frames: np.ndarray):
+        """Build an OPS Trajectory of snapshots from Angstrom frames.
+
+        Uses the engine's current snapshot as a template (topology / box /
+        velocities) and overwrites coordinates (converted nm). Velocities are
+        re-randomized by OPS shooting, so position-only seeding is sufficient.
+        """
+        template = self.ops_engine.current_snapshot
+        snapshots = []
+        for frame in frames:
+            snap = template.copy_with_replacement(coordinates=np.asarray(frame, dtype=float) / 10.0)
+            snapshots.append(snap)
+        return paths.Trajectory(snapshots)
+
+    def _analyze(self, paths, sampler, network) -> SamplingResult:
+        """Extract kinetics from the completed sampling run."""
+        meta = {"mode": self.mode, "n_steps": self.n_steps,
+                "storage": self.storage_path, "n_states": 2}
+        rate_constants = None
+        if self.mode == "tis":
+            try:
+                analysis = paths.TISAnalysis(network)
+                rate = analysis.rate_matrix(sampler.storage)
+                rate_constants = {"rate_matrix": np.asarray(rate)}
+            except Exception as exc:  # pragma: no cover - depends on live OPS run
+                meta["analysis_error"] = str(exc)
+        return SamplingResult(rate_constants=rate_constants, metadata=meta)

--- a/pathgennie/sampling/runner.py
+++ b/pathgennie/sampling/runner.py
@@ -1,0 +1,81 @@
+"""Glue that runs a configured downstream stage after path discovery.
+
+A backend ``run()`` calls :func:`run_downstream` when ``pathgennie.downstream`` is
+set in ``input.yaml``.  It assembles a :class:`PathEnsemble` from the driver's
+trajectory + restartable seed handles, constructs the named stage via
+:func:`pathgennie.sampling.make_stage`, runs it on the same engine, and writes the
+free-energy profile / rate constants next to the trajectory.
+
+This helper is engine-agnostic and unit-tested with the toy Langevin engine; the
+per-backend wiring (which supplies a real MD engine and seed handles) reuses it
+unchanged.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from typing import Callable, Optional, Sequence
+
+import numpy as np
+
+from .base import SamplingResult, build_path_ensemble
+
+__all__ = ["make_scalar_cv", "run_downstream", "write_result"]
+
+
+def make_scalar_cv(proj_fn: Callable[..., np.ndarray], projection_args: dict, component: int = 0) -> Callable[[np.ndarray], float]:
+    """Reduce a (possibly vector) projection to the scalar CV a stage bins along."""
+    args = projection_args or {}
+
+    def scalar(coords: np.ndarray) -> float:
+        v = np.atleast_1d(np.asarray(proj_fn(coords, **args), dtype=float))
+        return float(v[component])
+
+    return scalar
+
+
+def write_result(result: SamplingResult, output_dir: Path) -> None:
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    if result.free_energy is not None:
+        x = result.metadata.get("bin_centers")
+        if x is None:
+            x = result.metadata.get("grid")
+        with (output_dir / "free_energy.csv").open("w", newline="", encoding="utf-8") as fh:
+            writer = csv.writer(fh)
+            writer.writerow(["cv", "free_energy"])
+            fe = np.asarray(result.free_energy).ravel()
+            xs = np.asarray(x).ravel() if x is not None else [None] * fe.size
+            for xi, fi in zip(xs, fe):
+                writer.writerow(["" if xi is None else xi, fi])
+    if result.rate_constants is not None:
+        (output_dir / "rate_constants.json").write_text(
+            json.dumps(result.rate_constants, indent=2), encoding="utf-8"
+        )
+
+
+def run_downstream(
+    downstream: str,
+    stage_cfg: dict,
+    *,
+    engine,
+    traj: np.ndarray,
+    metrics: np.ndarray,
+    seed_handles: Optional[Sequence] = None,
+    scalar_cv_fn: Callable[[np.ndarray], float],
+    output_dir: Path,
+    state_labels: Optional[np.ndarray] = None,
+) -> SamplingResult:
+    """Build a PathEnsemble, run the named stage, and persist its result."""
+    from pathgennie.sampling import make_stage  # late import avoids any import cycle
+
+    ensemble = build_path_ensemble(
+        traj, metrics, handles=list(seed_handles) if seed_handles else None,
+        cv_fn=scalar_cv_fn, state_labels=state_labels,
+    )
+    stage = make_stage(downstream, cv_fn=scalar_cv_fn, **dict(stage_cfg))
+    result = stage.run(ensemble, engine)
+    write_result(result, output_dir)
+    return result

--- a/pathgennie/sampling/weighted_ensemble.py
+++ b/pathgennie/sampling/weighted_ensemble.py
@@ -1,0 +1,297 @@
+"""Path-informed Weighted Ensemble (WE) sampling stage.
+
+Weighted Ensemble keeps a population of trajectories ("walkers"), each carrying a
+statistical *weight*, propagates them with **unbiased** dynamics, and periodically
+*resamples* (splits over-weight walkers, merges under-weight ones) so that walkers
+stay spread across bins of a progress coordinate.  No bias force is ever applied —
+the weights make the ensemble unbiased — so WE reuses PathGennie's exact
+:class:`~pathgennie.core.engine.Engine` and
+:class:`~pathgennie.core.parallel.ParallelExecutor` (multi-GPU for free).
+
+This stage is *path-informed*: it seeds walkers from a discovered
+:class:`~pathgennie.sampling.base.PathEnsemble` and bins along that path's CV
+range, so WE does not have to first find the transition.  With recycling it
+yields a steady-state flux (rate constant); the time-averaged bin weights give a
+free-energy profile along the CV.
+
+Resampling follows the standard Huber & Kim (1996) split/merge scheme, which
+conserves total weight exactly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, List, Optional, Sequence
+
+import numpy as np
+
+from pathgennie.core.engine import Engine, Handle
+from pathgennie.core.parallel import ParallelExecutor, SerialExecutor
+
+from .base import PathEnsemble, SamplingResult
+
+__all__ = ["Walker", "GridBinner", "resample", "WeightedEnsembleStage"]
+
+
+@dataclass
+class Walker:
+    handle: Handle
+    weight: float
+    bin: int = -1
+    cv: float = float("nan")
+
+
+class GridBinner:
+    """Uniform 1-D bins over a progress coordinate."""
+
+    def __init__(self, edges: Sequence[float]):
+        self.edges = np.asarray(edges, dtype=float)
+        if self.edges.ndim != 1 or self.edges.size < 2 or not np.all(np.diff(self.edges) > 0):
+            raise ValueError("edges must be a strictly increasing 1-D sequence of length >= 2")
+        self.n_bins = self.edges.size - 1
+
+    @classmethod
+    def from_values(cls, values: Sequence[float], n_bins: int = 12, pad: float = 0.05) -> "GridBinner":
+        values = np.asarray(values, dtype=float).ravel()
+        lo, hi = float(values.min()), float(values.max())
+        if hi <= lo:
+            hi = lo + 1.0
+        span = hi - lo
+        edges = np.linspace(lo - pad * span, hi + pad * span, int(n_bins) + 1)
+        return cls(edges)
+
+    def bin_index(self, cv: float) -> int:
+        # np.digitize returns 1..len(edges)-1 for interior; clamp to [0, n_bins-1].
+        idx = int(np.digitize(float(cv), self.edges)) - 1
+        return max(0, min(self.n_bins - 1, idx))
+
+    @property
+    def centers(self) -> np.ndarray:
+        return 0.5 * (self.edges[:-1] + self.edges[1:])
+
+
+def resample(
+    walkers: List[Walker],
+    target_count: int,
+    rng: np.random.Generator,
+    clone_fn: Callable[[Handle], Handle],
+    release_fn: Callable[[Handle], None],
+) -> List[Walker]:
+    """Split/merge a single bin's walkers to exactly ``target_count``, conserving weight.
+
+    Splitting clones the largest-weight walker (halving its weight); merging
+    combines the two smallest-weight walkers into one (summed weight), keeping a
+    survivor chosen in proportion to weight and releasing the other.
+    """
+
+    walkers = list(walkers)
+    if not walkers or target_count < 1:
+        return walkers
+
+    # Split: grow to target_count by halving the heaviest walker each step.
+    while len(walkers) < target_count:
+        walkers.sort(key=lambda w: w.weight, reverse=True)
+        heavy = walkers[0]
+        half = heavy.weight / 2.0
+        heavy.weight = half
+        walkers.append(Walker(handle=clone_fn(heavy.handle), weight=half, bin=heavy.bin, cv=heavy.cv))
+
+    # Merge: shrink to target_count by combining the two lightest walkers.
+    while len(walkers) > target_count:
+        walkers.sort(key=lambda w: w.weight)
+        a, b = walkers[0], walkers[1]
+        total = a.weight + b.weight
+        # Survivor chosen proportional to weight; the other is dropped.
+        if total <= 0 or rng.random() < (a.weight / total if total > 0 else 0.5):
+            survivor, dropped = a, b
+        else:
+            survivor, dropped = b, a
+        survivor.weight = total
+        release_fn(dropped.handle)
+        walkers = [survivor] + walkers[2:]
+
+    return walkers
+
+
+class WeightedEnsembleStage:
+    """Run path-informed Weighted Ensemble over a :class:`PathEnsemble`.
+
+    ``cv_fn(coords) -> float`` maps an ``(n_atoms, 3)`` configuration to the scalar
+    progress coordinate WE bins along (reuse the discovery projection; reduce a
+    vector CV to one component or a norm).
+    """
+
+    def __init__(
+        self,
+        cv_fn: Callable[[np.ndarray], float],
+        *,
+        tau_steps: int,
+        n_iterations: int,
+        n_bins: int = 12,
+        bin_edges: Optional[Sequence[float]] = None,
+        target_count: int = 4,
+        continue_velocities: bool = True,
+        recycle: bool = False,
+        source_cv: Optional[float] = None,
+        target_cv: Optional[float] = None,
+        executor: Optional[ParallelExecutor] = None,
+        seed: int = 0,
+        timestep_ps: Optional[float] = None,
+        kT: float = 1.0,
+    ):
+        self.cv_fn = cv_fn
+        self.tau_steps = int(tau_steps)
+        self.n_iterations = int(n_iterations)
+        self.n_bins = int(n_bins)
+        self.bin_edges = bin_edges
+        self.target_count = int(target_count)
+        self.continue_velocities = bool(continue_velocities)
+        self.recycle = bool(recycle)
+        self.source_cv = source_cv
+        self.target_cv = target_cv
+        self.executor = executor or SerialExecutor()
+        self.seed = int(seed)
+        self.timestep_ps = timestep_ps
+        self.kT = float(kT)
+        if self.recycle and (self.source_cv is None or self.target_cv is None):
+            raise ValueError("recycle=True requires both source_cv and target_cv")
+
+    # -- seeding -------------------------------------------------------------
+    def _seed_handles(self, ensemble: PathEnsemble, engine: Engine) -> List[Handle]:
+        if ensemble.handles:
+            return list(ensemble.handles)
+        create_state = getattr(engine, "create_state", None)
+        if create_state is None:
+            raise ValueError(
+                "PathEnsemble has no restartable handles and the engine has no "
+                "create_state(coords); run the driver with collect_seeds=True or "
+                "use an engine that supports create_state."
+            )
+        return [create_state(frame) for frame in ensemble.frames]
+
+    def _cv(self, engine: Engine, handle: Handle) -> float:
+        return float(self.cv_fn(engine.get_coords(handle)))
+
+    # -- main loop -----------------------------------------------------------
+    def run(self, ensemble: PathEnsemble, engine: Engine, **_: object) -> SamplingResult:
+        rng = np.random.default_rng(self.seed)
+
+        # Binner: explicit edges, else from the path CV trajectory / frames.
+        if self.bin_edges is not None:
+            binner = GridBinner(self.bin_edges)
+        elif ensemble.cv_trajectory is not None:
+            binner = GridBinner.from_values(ensemble.cv_trajectory[:, 0], self.n_bins)
+        else:
+            values = [self.cv_fn(f) for f in ensemble.frames]
+            binner = GridBinner.from_values(values, self.n_bins)
+
+        seeds = self._seed_handles(ensemble, engine)
+        if not seeds:
+            raise ValueError("PathEnsemble produced no seed configurations")
+
+        def clone(handle: Handle) -> Handle:
+            return engine.clone_anchor(handle)
+
+        def release(handle: Handle) -> None:
+            engine.release(handle)
+
+        # Persistent source handle for recycling: an independent clone of the seed
+        # nearest source_cv that is never used as a walker (so it is never freed).
+        source_handle: Optional[Handle] = None
+        if self.recycle:
+            cvs = [self._cv(engine, h) for h in seeds]
+            nearest = int(np.argmin([abs(c - self.source_cv) for c in cvs]))
+            source_handle = engine.clone_anchor(seeds[nearest])
+
+        # Initialise one walker per seed, uniform weight, then balance per bin.
+        walkers: List[Walker] = []
+        w0 = 1.0 / len(seeds)
+        for handle in seeds:
+            cv = self._cv(engine, handle)
+            walkers.append(Walker(handle=handle, weight=w0, bin=binner.bin_index(cv), cv=cv))
+        walkers = self._resample_all(walkers, binner, rng, clone, release)
+
+        bin_weight = np.zeros(binner.n_bins, dtype=float)
+        weight_trace: List[float] = []
+        flux_total = 0.0
+
+        for _it in range(self.n_iterations):
+            seg_seeds = [int(rng.integers(1, 2_147_483_647)) for _ in walkers]
+
+            def worker(item, device):
+                walker, seg_seed = item
+                new_handle = engine.run_segment(
+                    walker.handle, self.tau_steps,
+                    randomize_velocities=not self.continue_velocities,
+                    seed=seg_seed, device=device,
+                )
+                return new_handle
+
+            new_handles = self.executor.map(worker, list(zip(walkers, seg_seeds)))
+            for walker, new_handle in zip(walkers, new_handles):
+                if new_handle is not walker.handle:
+                    engine.release(walker.handle)
+                walker.handle = new_handle
+                walker.cv = self._cv(engine, new_handle)
+                walker.bin = binner.bin_index(walker.cv)
+
+            # Recycle walkers that crossed the target back to the source.
+            if self.recycle:
+                forward = self.target_cv >= self.source_cv
+                for walker in walkers:
+                    crossed = walker.cv >= self.target_cv if forward else walker.cv <= self.target_cv
+                    if crossed:
+                        flux_total += walker.weight
+                        engine.release(walker.handle)
+                        walker.handle = clone(source_handle)
+                        walker.cv = self._cv(engine, walker.handle)
+                        walker.bin = binner.bin_index(walker.cv)
+
+            for walker in walkers:
+                bin_weight[walker.bin] += walker.weight
+            weight_trace.append(float(sum(w.weight for w in walkers)))
+
+            walkers = self._resample_all(walkers, binner, rng, clone, release)
+
+        # Free energy from time-averaged occupancy.
+        total = bin_weight.sum()
+        prob = bin_weight / total if total > 0 else bin_weight
+        with np.errstate(divide="ignore"):
+            free_energy = -self.kT * np.log(prob)
+        finite = free_energy[np.isfinite(free_energy)]
+        if finite.size:
+            free_energy = free_energy - finite.min()
+
+        rate_constants = None
+        if self.recycle:
+            flux_per_iter = flux_total / max(1, self.n_iterations)
+            if self.timestep_ps is not None:
+                tau_time = self.tau_steps * self.timestep_ps
+                rate = flux_per_iter / tau_time if tau_time > 0 else float("nan")
+            else:
+                rate = flux_per_iter  # per-iteration units
+            rate_constants = {"flux_per_iter": flux_per_iter, "rate": rate}
+
+        if source_handle is not None:
+            engine.release(source_handle)
+
+        return SamplingResult(
+            free_energy=free_energy,
+            rate_constants=rate_constants,
+            weights=np.array([w.weight for w in walkers], dtype=float),
+            metadata={
+                "bin_centers": binner.centers,
+                "bin_probability": prob,
+                "weight_trace": np.asarray(weight_trace),
+                "n_walkers": len(walkers),
+            },
+        )
+
+    def _resample_all(self, walkers, binner, rng, clone, release):
+        by_bin: dict = {}
+        for walker in walkers:
+            by_bin.setdefault(walker.bin, []).append(walker)
+        out: List[Walker] = []
+        for members in by_bin.values():
+            out.extend(resample(members, self.target_count, rng, clone, release))
+        return out

--- a/pathgennie/search/__init__.py
+++ b/pathgennie/search/__init__.py
@@ -1,0 +1,20 @@
+"""Non-linear path search for PathGennie.
+
+``rrt`` provides Rapidly-exploring Random Tree search (RRT and bidirectional
+RRT-Connect) over the swarm, for pathways the greedy metric cannot follow.
+``roadmap`` maintains a conformational graph and extracts the minimum-free-energy
+and competing pathways between metastable states.
+"""
+
+from .rrt import RRT, Node, RRTResult, rrt_connect
+from .roadmap import Roadmap, dijkstra_path, k_shortest_paths
+
+__all__ = [
+    "RRT",
+    "Node",
+    "RRTResult",
+    "rrt_connect",
+    "Roadmap",
+    "dijkstra_path",
+    "k_shortest_paths",
+]

--- a/pathgennie/search/roadmap.py
+++ b/pathgennie/search/roadmap.py
@@ -1,0 +1,174 @@
+"""Conformational roadmap graph and all-pairs pathway extraction.
+
+PathGennie / RRT discover *transitions*; the roadmap turns the accumulated
+transitions into a global weighted graph and extracts pathways between metastable
+states.  Nodes are states (e.g. SPIB metastable-state labels, Phase 3); a
+directed edge ``u -> v`` is weighted by ``-log(transition fraction)``, a
+free-energy-like cost so that the *minimum-cost* path is the
+*maximum-likelihood / minimum-free-energy* route.
+
+- :func:`dijkstra_path` — the single minimum-cost path between two states.
+- :func:`k_shortest_paths` — Yen's algorithm for the *competing parallel*
+  pathways (formalising the paper's post-hoc egress-route clustering).
+- :class:`Roadmap` — accumulates transition counts (e.g. from a state-label
+  trajectory) and exposes both, plus an all-pairs report.
+
+Pure NumPy/standard-library; no external graph dependency.
+"""
+
+from __future__ import annotations
+
+import heapq
+import math
+from collections import defaultdict
+from typing import Dict, Hashable, List, Optional, Tuple
+
+__all__ = ["dijkstra_path", "k_shortest_paths", "Roadmap"]
+
+Adjacency = Dict[Hashable, Dict[Hashable, float]]
+
+
+def dijkstra_path(adj: Adjacency, source: Hashable, target: Hashable) -> Tuple[float, List[Hashable]]:
+    """Minimum-cost path ``source -> target``; returns ``(cost, path)``.
+
+    ``(inf, [])`` if unreachable. Edge weights must be non-negative.
+    """
+
+    if source == target:
+        return 0.0, [source]
+    dist: Dict[Hashable, float] = {source: 0.0}
+    prev: Dict[Hashable, Hashable] = {}
+    pq: List[Tuple[float, Hashable]] = [(0.0, source)]
+    visited = set()
+    while pq:
+        d, u = heapq.heappop(pq)
+        if u in visited:
+            continue
+        visited.add(u)
+        if u == target:
+            break
+        for v, w in adj.get(u, {}).items():
+            nd = d + w
+            if nd < dist.get(v, math.inf):
+                dist[v] = nd
+                prev[v] = u
+                heapq.heappush(pq, (nd, v))
+    if target not in dist:
+        return math.inf, []
+    path = [target]
+    while path[-1] != source:
+        path.append(prev[path[-1]])
+    path.reverse()
+    return dist[target], path
+
+
+def k_shortest_paths(adj: Adjacency, source: Hashable, target: Hashable, k: int) -> List[Tuple[float, List[Hashable]]]:
+    """Yen's algorithm: up to ``k`` shortest loopless paths, increasing cost.
+
+    ``adj`` is treated as read-only (a working copy is used for spur searches).
+    """
+
+    cost0, path0 = dijkstra_path(adj, source, target)
+    if not path0:
+        return []
+    accepted: List[Tuple[float, List[Hashable]]] = [(cost0, path0)]
+    candidates: List[Tuple[float, List[Hashable]]] = []
+
+    while len(accepted) < k:
+        _, prev_path = accepted[-1]
+        for i in range(len(prev_path) - 1):
+            spur_node = prev_path[i]
+            root_path = prev_path[: i + 1]
+
+            work: Adjacency = {u: dict(nbrs) for u, nbrs in adj.items()}
+            # Remove the edge each known path takes after this root, and the
+            # interior root nodes, so the spur search yields a genuinely new path.
+            for _, p in accepted:
+                if len(p) > i and p[: i + 1] == root_path and p[i] in work and p[i + 1] in work[p[i]]:
+                    del work[p[i]][p[i + 1]]
+            for node in root_path[:-1]:
+                work.pop(node, None)
+                for nbrs in work.values():
+                    nbrs.pop(node, None)
+
+            _, spur_path = dijkstra_path(work, spur_node, target)
+            if spur_path:
+                total_path = root_path[:-1] + spur_path
+                total_cost = _path_cost(adj, total_path)
+                pair = (total_cost, total_path)
+                if pair not in candidates and pair not in accepted:
+                    candidates.append(pair)
+
+        if not candidates:
+            break
+        candidates.sort(key=lambda c: (c[0], [str(n) for n in c[1]]))
+        accepted.append(candidates.pop(0))
+
+    return accepted
+
+
+def _path_cost(adj: Adjacency, path: List[Hashable]) -> float:
+    total = 0.0
+    for u, v in zip(path, path[1:]):
+        if u not in adj or v not in adj[u]:
+            return math.inf
+        total += adj[u][v]
+    return total
+
+
+class Roadmap:
+    """Accumulate transitions and extract pathways between states."""
+
+    def __init__(self) -> None:
+        self._counts: Dict[Tuple[Hashable, Hashable], float] = defaultdict(float)
+        self._nodes: set = set()
+
+    @property
+    def nodes(self) -> List[Hashable]:
+        return sorted(self._nodes, key=lambda x: (str(type(x)), x))
+
+    def add_transition(self, u: Hashable, v: Hashable, count: float = 1.0) -> None:
+        self._counts[(u, v)] += float(count)
+        self._nodes.add(u)
+        self._nodes.add(v)
+
+    def observe_sequence(self, labels) -> None:
+        """Accumulate transitions from a state-label trajectory (e.g. SPIB labels)."""
+        labels = list(labels)
+        for u, v in zip(labels, labels[1:]):
+            if u != v:
+                self.add_transition(u, v)
+
+    def adjacency(self, *, self_loops: bool = False, eps: float = 1e-12) -> Adjacency:
+        """Edge weights ``-log(p(u->v))`` from accumulated transition counts."""
+        out_total: Dict[Hashable, float] = defaultdict(float)
+        for (u, v), c in self._counts.items():
+            if not self_loops and u == v:
+                continue
+            out_total[u] += c
+        adj: Adjacency = {}
+        for (u, v), c in self._counts.items():
+            if not self_loops and u == v:
+                continue
+            p = c / out_total[u] if out_total[u] > 0 else eps
+            adj.setdefault(u, {})[v] = -math.log(max(p, eps))
+        return adj
+
+    def min_free_energy_path(self, source: Hashable, target: Hashable) -> Tuple[float, List[Hashable]]:
+        return dijkstra_path(self.adjacency(), source, target)
+
+    def k_shortest_paths(self, source: Hashable, target: Hashable, k: int = 3) -> List[Tuple[float, List[Hashable]]]:
+        return k_shortest_paths(self.adjacency(), source, target, k)
+
+    def all_pairs_paths(self, k: int = 1) -> Dict[Tuple[Hashable, Hashable], List[Tuple[float, List[Hashable]]]]:
+        """All-pairs pathway report; ``k`` competing routes per ordered pair."""
+        adj = self.adjacency()
+        report: Dict[Tuple[Hashable, Hashable], List[Tuple[float, List[Hashable]]]] = {}
+        for s in self.nodes:
+            for t in self.nodes:
+                if s == t:
+                    continue
+                paths = k_shortest_paths(adj, s, t, k)
+                if paths:
+                    report[(s, t)] = paths
+        return report

--- a/pathgennie/search/rrt.py
+++ b/pathgennie/search/rrt.py
@@ -1,0 +1,223 @@
+"""Rapidly-exploring Random Trees (RRT / RRT-Connect) over a PathGennie swarm.
+
+The greedy driver follows a monotone progress metric, so it cannot backtrack,
+change direction, or move orthogonally to the CV — the failure mode the paper
+shows on Wolfe-Quapp.  RRT reframes each expansion as growing a tree in CV space:
+
+1. sample a random CV target ``q_rand`` (occasionally the goal — *goal biasing*);
+2. find the nearest existing tree node ``q_near`` (by CV distance);
+3. run a PathGennie swarm from ``q_near`` and select the sampler whose CV moves
+   closest to ``q_rand`` — i.e. the existing
+   :func:`~pathgennie.core.selection.softmax_select` with metric ``-||cv-q_rand||``;
+4. extend the chosen sampler with a ``tau2`` runner and add it as a new node.
+
+Because targets can point in *any* CV direction and the tree remembers every
+node, the search backtracks and explores naturally.  **RRT-Connect** grows two
+trees — from the start and from a goal configuration — and links them, which
+crosses barriers far faster.
+
+This reuses the shared :class:`~pathgennie.core.engine.Engine` and
+:class:`~pathgennie.core.parallel.ParallelExecutor`, so RRT is multi-GPU for free
+and works with any backend (including the toy Langevin engine used in tests).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, List, Optional, Sequence
+
+import numpy as np
+
+from pathgennie.core.engine import Engine, Handle
+from pathgennie.core.parallel import ParallelExecutor, SerialExecutor
+from pathgennie.core.selection import softmax_select
+
+__all__ = ["Node", "RRTResult", "RRT", "rrt_connect"]
+
+
+@dataclass
+class Node:
+    id: int
+    handle: Handle
+    cv: np.ndarray
+    parent: Optional[int] = None
+
+
+@dataclass
+class RRTResult:
+    success: bool
+    path: List[Node]          # root -> goal (empty if not successful)
+    tree_size: int
+    goal_node: Optional[Node] = None
+
+
+class RRT:
+    """A single rapidly-exploring random tree in CV space."""
+
+    def __init__(
+        self,
+        engine: Engine,
+        cv_fn: Callable[[np.ndarray], np.ndarray],
+        *,
+        lower: Sequence[float],
+        upper: Sequence[float],
+        tau1: int = 5,
+        tau2: int = 10,
+        n_expand: int = 8,
+        sigma: float = 0.05,
+        goal_bias: float = 0.1,
+        executor: Optional[ParallelExecutor] = None,
+        seed: int = 0,
+    ):
+        self.engine = engine
+        self.cv_fn = cv_fn
+        self.lower = np.asarray(lower, dtype=float)
+        self.upper = np.asarray(upper, dtype=float)
+        self.tau1 = int(tau1)
+        self.tau2 = int(tau2)
+        self.n_expand = int(n_expand)
+        self.sigma = float(sigma)
+        self.goal_bias = float(goal_bias)
+        self.executor = executor or SerialExecutor()
+        self.rng = np.random.default_rng(seed)
+        self.nodes: List[Node] = []
+
+    # -- helpers -------------------------------------------------------------
+    def _cv(self, handle: Handle) -> np.ndarray:
+        return np.atleast_1d(np.asarray(self.cv_fn(self.engine.get_coords(handle)), dtype=float))
+
+    def add_node(self, handle: Handle, parent: Optional[int]) -> Node:
+        node = Node(id=len(self.nodes), handle=handle, cv=self._cv(handle), parent=parent)
+        self.nodes.append(node)
+        return node
+
+    def _seed(self) -> int:
+        return int(self.rng.integers(1, 2_147_483_647))
+
+    def sample_target(self, goal_cv: Optional[np.ndarray]) -> np.ndarray:
+        if goal_cv is not None and self.rng.random() < self.goal_bias:
+            return np.asarray(goal_cv, dtype=float)
+        return self.rng.uniform(self.lower, self.upper)
+
+    def nearest(self, q: np.ndarray) -> Node:
+        cvs = np.stack([n.cv for n in self.nodes])
+        d = np.linalg.norm(cvs - np.asarray(q, dtype=float), axis=1)
+        return self.nodes[int(d.argmin())]
+
+    # -- expansion -----------------------------------------------------------
+    def extend(self, node: Node, q_rand: np.ndarray) -> Node:
+        """Grow one new node from ``node`` toward ``q_rand`` via a swarm + runner."""
+        q_rand = np.asarray(q_rand, dtype=float)
+        seg_seeds = [self._seed() for _ in range(self.n_expand)]
+
+        def worker(seg_seed, device):
+            handle = self.engine.clone_anchor(node.handle)
+            return self.engine.run_segment(
+                handle, self.tau1, randomize_velocities=True, seed=seg_seed, device=device
+            )
+
+        trials = self.executor.map(worker, seg_seeds)
+        cvs = [self._cv(t) for t in trials]
+        metrics = np.array([-np.linalg.norm(cv - q_rand) for cv in cvs], dtype=float)
+        chosen_idx = softmax_select(metrics, self.sigma, self.rng)
+        chosen = trials[chosen_idx]
+        for j, t in enumerate(trials):
+            if j != chosen_idx:
+                self.engine.release(t)
+
+        runner = self.engine.run_segment(
+            chosen, self.tau2, randomize_velocities=False,
+            seed=self._seed(), device=self.executor.devices[0],
+        )
+        if runner is not chosen:
+            self.engine.release(chosen)
+        return self.add_node(runner, node.id)
+
+    def path_to(self, node: Node) -> List[Node]:
+        chain: List[Node] = []
+        current: Optional[Node] = node
+        while current is not None:
+            chain.append(current)
+            current = self.nodes[current.parent] if current.parent is not None else None
+        chain.reverse()
+        return chain
+
+    # -- top-level driver ----------------------------------------------------
+    def build(
+        self,
+        initial_handle: Handle,
+        *,
+        target_cv: Optional[Sequence[float]] = None,
+        max_iter: int = 200,
+        goal_tol: float = 0.3,
+    ) -> RRTResult:
+        goal = None if target_cv is None else np.asarray(target_cv, dtype=float)
+        self.add_node(self.engine.clone_anchor(initial_handle), None)
+
+        for _ in range(max_iter):
+            q = self.sample_target(goal)
+            new = self.extend(self.nearest(q), q)
+            if goal is not None and np.linalg.norm(new.cv - goal) <= goal_tol:
+                return RRTResult(True, self.path_to(new), len(self.nodes), new)
+
+        if goal is not None:
+            cvs = np.stack([n.cv for n in self.nodes])
+            best = self.nodes[int(np.linalg.norm(cvs - goal, axis=1).argmin())]
+            return RRTResult(False, self.path_to(best), len(self.nodes), best)
+        return RRTResult(False, [], len(self.nodes), None)
+
+
+def rrt_connect(
+    engine: Engine,
+    cv_fn: Callable[[np.ndarray], np.ndarray],
+    start_handle: Handle,
+    goal_handle: Handle,
+    *,
+    lower: Sequence[float],
+    upper: Sequence[float],
+    tau1: int = 5,
+    tau2: int = 10,
+    n_expand: int = 8,
+    sigma: float = 0.05,
+    executor: Optional[ParallelExecutor] = None,
+    seed: int = 0,
+    max_iter: int = 200,
+    connect_tol: float = 0.3,
+) -> RRTResult:
+    """Bidirectional RRT-Connect between two configurations.
+
+    Grows a tree from ``start_handle`` and another from ``goal_handle``; each
+    iteration one tree extends toward a random target and the other greedily
+    extends toward the new node until they are within ``connect_tol`` in CV space.
+    Returns the joined start->goal path.
+    """
+
+    common = dict(lower=lower, upper=upper, tau1=tau1, tau2=tau2, n_expand=n_expand,
+                  sigma=sigma, goal_bias=0.0, executor=executor)
+    tree_a = RRT(engine, cv_fn, seed=seed, **common)
+    tree_b = RRT(engine, cv_fn, seed=seed + 1, **common)
+    tree_a.add_node(engine.clone_anchor(start_handle), None)
+    tree_b.add_node(engine.clone_anchor(goal_handle), None)
+
+    a, b = tree_a, tree_b
+    a_is_start = True
+    for _ in range(max_iter):
+        q = a.sample_target(None)
+        a_new = a.extend(a.nearest(q), q)
+
+        # Greedily grow b toward a_new.
+        b_node = b.extend(b.nearest(a_new.cv), a_new.cv)
+        if np.linalg.norm(b_node.cv - a_new.cv) <= connect_tol:
+            path_a = a.path_to(a_new)
+            path_b = b.path_to(b_node)
+            # Order the joined path start -> goal.
+            if a_is_start:
+                joined = path_a + list(reversed(path_b))
+            else:
+                joined = path_b + list(reversed(path_a))
+            return RRTResult(True, joined, len(a.nodes) + len(b.nodes), a_new)
+
+        a, b = b, a
+        a_is_start = not a_is_start
+
+    return RRTResult(False, [], len(tree_a.nodes) + len(tree_b.nodes), None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ dependencies = [
 examples = [
   "ParmEd",
 ]
+dev = [
+  "pytest",
+]
 
 [project.scripts]
 pathgennie-amber = "pathgennie.backends.amber.pg_amber:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ examples = [
 dev = [
   "pytest",
 ]
+ml = [
+  "torch",
+]
 
 [project.scripts]
 pathgennie-amber = "pathgennie.backends.amber.pg_amber:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,9 @@ dev = [
 ml = [
   "torch",
 ]
+pathsampling = [
+  "openpathsampling",
+]
 
 [project.scripts]
 pathgennie-amber = "pathgennie.backends.amber.pg_amber:main"

--- a/tests/test_amber_engine.py
+++ b/tests/test_amber_engine.py
@@ -1,0 +1,80 @@
+"""Validate the device-aware AMBER engine without a real pmemd binary.
+
+``subprocess.run`` is faked to copy the input restart to the output path (so
+coordinates flow through the driver) and to record the ``CUDA_VISIBLE_DEVICES``
+each segment was launched with.  This lets us assert the two behaviours the
+multi-GPU refactor is responsible for: trials are spread across the configured
+devices, and each device gets an isolated scratch subdirectory.
+"""
+
+import threading
+from pathlib import Path
+
+import numpy as np
+
+import pathgennie.backends.amber.engine as amber_engine
+from pathgennie.backends.amber.engine import CoreAmberEngine
+from pathgennie.backends.amber.utils import default_mdin_controls
+from pathgennie.core.driver import PathGennieDriver
+from pathgennie.core.parallel import ThreadDevicePool
+from pathgennie.core.progress import EscapeMetric
+
+REPO = Path(__file__).resolve().parents[1]
+RST7 = REPO / "examples" / "alanine_dipeptide" / "common" / "ala_dipeptide_equilibrated.rst7"
+
+
+def _install_fake_pmemd(monkeypatch, recorder, lock):
+    def fake_run(cmd, check=True, capture_output=True, text=True, env=None):
+        in_path = cmd[cmd.index("-c") + 1]
+        out_path = cmd[cmd.index("-r") + 1]
+        Path(out_path).write_bytes(Path(in_path).read_bytes())
+        with lock:
+            recorder.append({
+                "device": (env or {}).get("CUDA_VISIBLE_DEVICES"),
+                "out_dir": str(Path(out_path).parent),
+            })
+        return None
+
+    monkeypatch.setattr(amber_engine.subprocess, "run", fake_run)
+
+
+def test_amber_swarm_spreads_across_devices(tmp_path, monkeypatch):
+    recorder = []
+    lock = threading.Lock()
+    _install_fake_pmemd(monkeypatch, recorder, lock)
+
+    engine = CoreAmberEngine(
+        topology=RST7,  # never read by the fake; any existing file works
+        executable=Path("/bin/true"),
+        scratch_dir=tmp_path / "scratch",
+        temperature=300.0,
+        mdin_controls=default_mdin_controls("vacuum"),
+    )
+    progress = EscapeMetric(lambda c: np.array([c[0, 0]]), start_cv=np.array([0.0]), escape_metric="cv0")
+
+    driver = PathGennieDriver(
+        engine, progress, convergence_fn=lambda c: False,
+        executor=ThreadDevicePool(devices=[0, 1, 2, 3], workers_per_device=1),
+        sigma=0.1, seed=1, verbosity=0,
+    )
+    driver.run(str(RST7), tau1=1, tau2=1, max_trial=8, max_cycle=2, save_freq=1)
+
+    sampler_devices = {r["device"] for r in recorder}
+    # All four GPUs should have been used by the samplers (runner uses device 0).
+    assert {"0", "1", "2", "3"}.issubset(sampler_devices)
+    # Each device wrote into its own scratch subdirectory.
+    dev_dirs = {Path(r["out_dir"]).name for r in recorder}
+    assert {"dev0", "dev1", "dev2", "dev3"}.issubset(dev_dirs)
+
+
+def test_amber_single_device_sets_env(tmp_path, monkeypatch):
+    recorder = []
+    _install_fake_pmemd(monkeypatch, recorder, threading.Lock())
+    engine = CoreAmberEngine(
+        topology=RST7, executable=Path("/bin/true"),
+        scratch_dir=tmp_path / "scratch", temperature=300.0,
+        mdin_controls=default_mdin_controls("vacuum"),
+    )
+    h = engine.run_segment(str(RST7), 1, randomize_velocities=True, seed=5, device=2)
+    assert Path(h).exists()
+    assert recorder[-1]["device"] == "2"

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,0 +1,58 @@
+"""Rule-based agentic controller tests."""
+
+from pathgennie.agent import RuleBasedController, SwarmParams
+
+
+def _controller(**kw):
+    return RuleBasedController(SwarmParams(n_trial=8, tau1=4, tau2=8), **kw)
+
+
+def test_escalates_when_stalling():
+    c = _controller(stall_window=4, escalate=2.0)
+    flat = [0.0, 0.0, 0.0, 0.0, 0.0]
+    p = c.update(flat)
+    assert p.n_trial > 8          # swarm enlarged
+    assert p.tau1 > 4             # sampler lengthened
+    assert p.tau2 > 8
+
+
+def test_relaxes_when_progressing():
+    c = _controller(stall_window=4, relax=0.5)
+    improving = [0.0, 1.0, 2.0, 3.0, 4.0]
+    p = c.update(improving)
+    assert p.n_trial < 8          # swarm shrunk to save compute
+
+
+def test_respects_bounds():
+    c = _controller(n_bounds=(4, 10), tau1_bounds=(2, 5), tau2_bounds=(4, 9), escalate=10.0)
+    p = c.update([0.0, 0.0, 0.0])
+    assert p.n_trial <= 10 and p.tau1 <= 5 and p.tau2 <= 9
+
+
+def test_should_stop_on_plateau():
+    c = _controller(stop_patience=3, stall_eps=1e-6)
+    # First call sets the best; subsequent flat calls accrue no-improvement count.
+    for _ in range(5):
+        c.update([1.0, 1.0, 1.0])
+    assert c.should_stop([1.0, 1.0, 1.0])
+
+
+def test_should_not_stop_while_improving():
+    c = _controller(stop_patience=3)
+    hist = [0.0]
+    for v in range(1, 6):
+        hist.append(float(v))
+        c.update(hist)
+    assert not c.should_stop(hist)
+
+
+def test_refresh_schedule():
+    c = _controller(refresh_every=10)
+    assert c.should_refresh_cv(0) is True      # first time
+    assert c.should_refresh_cv(5) is False
+    assert c.should_refresh_cv(10) is True
+    assert c.should_refresh_cv(11) is False
+
+
+def test_choose_frontier_least_visited():
+    assert RuleBasedController.choose_frontier([3, 1, 2, 5]) == 1

--- a/tests/test_cv.py
+++ b/tests/test_cv.py
@@ -1,0 +1,57 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "examples" / "alanine_dipeptide" / "common"))
+
+import phi_psi  # noqa: E402
+
+from pathgennie.core.progress import EscapeMetric, TargetMetric  # noqa: E402
+
+
+def test_dihedral_known_geometry():
+    # Atoms placed so the 0-1-2-3 dihedral is exactly +90 degrees.
+    coords = np.array(
+        [
+            [1.0, 0.0, 0.0],   # p0
+            [0.0, 0.0, 0.0],   # p1
+            [0.0, 0.0, 1.0],   # p2 (axis along z)
+            [0.0, 1.0, 1.0],   # p3
+        ]
+    )
+    angle = phi_psi.dihedral_degrees(coords, (0, 1, 2, 3))
+    assert np.isclose(abs(angle), 90.0, atol=1e-6)
+
+
+def test_phi_psi_cv_shape():
+    rng = np.random.default_rng(0)
+    coords = rng.standard_normal((20, 3))
+    cv = phi_psi.phi_psi_cv(coords)
+    assert cv.shape == (2,)
+
+
+def test_angular_wrap():
+    # 170 and -170 degrees are 20 degrees apart, not 340.
+    delta = phi_psi.angular_delta_degrees([170.0], [-170.0])
+    assert np.isclose(abs(delta[0]), 20.0)
+    assert phi_psi.reached_phi_psi.__doc__ is None or True  # smoke
+
+
+def test_target_metric_is_negated_distance():
+    pv = TargetMetric(lambda c: np.array([c[0, 0], c[0, 1]]), target_cv=np.array([0.0, 0.0]))
+    near = pv.metric(np.array([0.1, 0.1]))
+    far = pv.metric(np.array([5.0, 5.0]))
+    assert near > far
+    assert np.isclose(pv.metric(np.array([3.0, 4.0])), -5.0)
+
+
+def test_escape_metric_distance_from_start():
+    pv = EscapeMetric(lambda c: c, start_cv=np.array([0.0, 0.0]), escape_metric="distance_from_start")
+    assert np.isclose(pv.metric(np.array([3.0, 4.0])), 5.0)
+
+
+def test_escape_metric_cv0():
+    pv = EscapeMetric(lambda c: c, start_cv=np.array([0.0, 0.0]), escape_metric="cv0")
+    assert np.isclose(pv.metric(np.array([7.0, 2.0])), 7.0)

--- a/tests/test_downstream_runner.py
+++ b/tests/test_downstream_runner.py
@@ -1,0 +1,44 @@
+"""Toy-engine coverage for the downstream-stage glue used by the backends."""
+
+import numpy as np
+
+from pathgennie.core.driver import PathGennieDriver
+from pathgennie.core.parallel import SerialExecutor
+from pathgennie.core.progress import EscapeMetric
+from pathgennie.core.toy import ToyLangevinEngine
+from pathgennie.sampling.runner import make_scalar_cv, run_downstream
+
+
+def test_make_scalar_cv_reduces_vector():
+    def proj(coords, scale=1.0):
+        return np.array([coords[0, 0] * scale, coords[0, 1]])
+
+    f0 = make_scalar_cv(proj, {"scale": 2.0}, component=0)
+    f1 = make_scalar_cv(proj, {"scale": 2.0}, component=1)
+    coords = np.array([[3.0, -4.0, 0.0]])
+    assert f0(coords) == 6.0
+    assert f1(coords) == -4.0
+
+
+def test_run_downstream_weighted_ensemble_writes_outputs(tmp_path):
+    engine = ToyLangevinEngine(dt=0.005, kT=2.0)
+    initial = engine.create_state((-1.0, -1.4))
+    scalar_cv = make_scalar_cv(lambda c: np.array([c[0, 1]]), {}, 0)
+    progress = EscapeMetric(lambda c: np.array([c[0, 1]]), start_cv=np.array([-1.4]), escape_metric="cv0")
+    driver = PathGennieDriver(engine, progress, lambda c: False,
+                              executor=SerialExecutor(), sigma=0.3, seed=0, verbosity=0)
+    traj, metrics, seeds = driver.run(initial, tau1=5, tau2=10, max_trial=5,
+                                      max_cycle=20, save_freq=2, collect_seeds=True)
+
+    result = run_downstream(
+        "weighted_ensemble",
+        {"tau_steps": 5, "n_iterations": 10, "n_bins": 8, "target_count": 4, "seed": 1},
+        engine=engine, traj=traj, metrics=metrics, seed_handles=seeds,
+        scalar_cv_fn=scalar_cv, output_dir=tmp_path,
+    )
+    assert result.free_energy is not None
+    assert (tmp_path / "free_energy.csv").exists()
+    # Header + one row per bin center.
+    lines = (tmp_path / "free_energy.csv").read_text().strip().splitlines()
+    assert lines[0] == "cv,free_energy"
+    assert len(lines) == 1 + result.free_energy.size

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,0 +1,40 @@
+import numpy as np
+
+from pathgennie.cv.features import (
+    Featurizer,
+    contact_features,
+    dihedral_features,
+    pairwise_distances,
+)
+
+
+def test_pairwise_distances():
+    coords = np.array([[0.0, 0.0, 0.0], [3.0, 4.0, 0.0], [0.0, 0.0, 1.0]])
+    d = pairwise_distances(coords, [[0, 1], [0, 2]])
+    np.testing.assert_allclose(d, [5.0, 1.0])
+
+
+def test_contact_features_monotone():
+    coords = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [20.0, 0.0, 0.0]])
+    c = contact_features(coords, [[0, 1], [0, 2]], r0=8.0)
+    assert c[0] > c[1]  # closer pair has the larger contact value
+    assert 0.0 <= c[1] < 0.2
+
+
+def test_dihedral_features_unit_circle():
+    coords = np.array([[1, 0, 0], [0, 0, 0], [0, 0, 1], [0, 1, 1]], dtype=float)
+    f = dihedral_features(coords, [[0, 1, 2, 3]])
+    assert f.shape == (2,)
+    np.testing.assert_allclose(f[0] ** 2 + f[1] ** 2, 1.0, atol=1e-6)  # sin^2+cos^2
+
+
+def test_featurizer_standardize():
+    rng = np.random.default_rng(0)
+    batch = [rng.standard_normal((4, 3)) for _ in range(200)]
+    feat = Featurizer(funcs=[], standardize=True).fit(batch)
+    assert feat.n_features == 12
+    transformed = feat.transform_batch(batch)
+    assert transformed.shape == (200, 12)
+    # Standardized columns should be ~zero mean, ~unit variance.
+    np.testing.assert_allclose(transformed.mean(axis=0), 0.0, atol=0.1)
+    np.testing.assert_allclose(transformed.std(axis=0), 1.0, atol=0.1)

--- a/tests/test_gromacs_engine.py
+++ b/tests/test_gromacs_engine.py
@@ -1,0 +1,72 @@
+"""Validate the device-aware GROMACS engine without real gmx binaries.
+
+Fakes ``subprocess.run`` for both ``gmx grompp`` (records the input structure
+behind the produced .tpr) and ``gmx mdrun`` (copies that structure to the output
+.gro and records the device).  Asserts the swarm spreads across devices and uses
+isolated per-device scratch directories.
+"""
+
+import threading
+from pathlib import Path
+
+import numpy as np
+
+import pathgennie.backends.gromacs.pg_gmx as pg_gmx
+from pathgennie.backends.gromacs.pg_gmx import CoreGromacsEngine
+from pathgennie.core.driver import PathGennieDriver
+from pathgennie.core.parallel import ThreadDevicePool
+from pathgennie.core.progress import EscapeMetric
+
+REPO = Path(__file__).resolve().parents[1]
+GRO = REPO / "examples" / "alanine_dipeptide" / "gromacs" / "ala_dipeptide_equilibrated.gro"
+
+
+def _install_fake_gmx(monkeypatch, recorder, lock):
+    tpr_inputs: dict[str, str] = {}
+
+    def fake_run(cmd, check=True, capture_output=True, text=True, env=None):
+        stage = cmd[1]
+        if stage == "grompp":
+            in_gro = cmd[cmd.index("-c") + 1]
+            tpr = cmd[cmd.index("-o") + 1]
+            with lock:
+                tpr_inputs[tpr] = in_gro
+            Path(tpr).write_text("fake-tpr")
+        elif stage == "mdrun":
+            tpr = cmd[cmd.index("-s") + 1]
+            out_gro = cmd[cmd.index("-c") + 1]
+            out_cpt = cmd[cmd.index("-cpo") + 1]
+            Path(out_gro).write_bytes(Path(tpr_inputs[tpr]).read_bytes())
+            Path(out_cpt).write_text("fake-cpt")
+            with lock:
+                recorder.append({
+                    "device": (env or {}).get("CUDA_VISIBLE_DEVICES"),
+                    "out_dir": str(Path(out_gro).parent),
+                })
+        return None
+
+    monkeypatch.setattr(pg_gmx.subprocess, "run", fake_run)
+
+
+def test_gromacs_swarm_spreads_across_devices(tmp_path, monkeypatch):
+    recorder = []
+    lock = threading.Lock()
+    _install_fake_gmx(monkeypatch, recorder, lock)
+
+    engine = CoreGromacsEngine(
+        topology=GRO, executable=Path("/bin/true"),
+        scratch_dir=tmp_path / "scratch", temperature=300.0,
+        mdp_controls={"integrator": "md", "dt": 0.002},
+    )
+    progress = EscapeMetric(lambda c: np.array([c[0, 0]]), start_cv=np.array([0.0]), escape_metric="cv0")
+    driver = PathGennieDriver(
+        engine, progress, convergence_fn=lambda c: False,
+        executor=ThreadDevicePool(devices=[0, 1, 2, 3], workers_per_device=1),
+        sigma=0.1, seed=1, verbosity=0,
+    )
+    driver.run(str(GRO), tau1=1, tau2=1, max_trial=8, max_cycle=2, save_freq=1)
+
+    devices = {r["device"] for r in recorder}
+    assert {"0", "1", "2", "3"}.issubset(devices)
+    dev_dirs = {Path(r["out_dir"]).name for r in recorder}
+    assert {"dev0", "dev1", "dev2", "dev3"}.issubset(dev_dirs)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+import numpy as np
+
+from pathgennie.backends.amber.utils import (
+    parse_prmtop,
+    read_rst7_coords,
+    wrap_frames_pbc,
+    write_multimodel_pdb,
+)
+
+REPO = Path(__file__).resolve().parents[1]
+COMMON = REPO / "examples" / "alanine_dipeptide" / "common"
+PRMTOP = COMMON / "ala_dipeptide.prmtop"
+RST7 = COMMON / "ala_dipeptide_equilibrated.rst7"
+
+
+def test_rst7_read_shape():
+    coords = read_rst7_coords(RST7)
+    assert coords.ndim == 2 and coords.shape[1] == 3
+    assert np.all(np.isfinite(coords))
+
+
+def test_prmtop_atom_mass_consistency():
+    info = parse_prmtop(PRMTOP)
+    assert len(info["atom_names"]) == len(info["masses"])
+    coords = read_rst7_coords(RST7)
+    assert coords.shape[0] == len(info["atom_names"])
+
+
+def test_multimodel_pdb_roundtrip(tmp_path):
+    info = parse_prmtop(PRMTOP)
+    n_atoms = len(info["atom_names"])
+    frames = np.zeros((2, n_atoms, 3), dtype=float)
+    frames[1] += 1.0
+    out = tmp_path / "traj.pdb"
+    write_multimodel_pdb(out, info, frames)
+    text = out.read_text()
+    assert text.count("MODEL") == 2
+    assert text.count("ENDMDL") == 2
+    # Coordinates should be parseable back from the fixed-width records.
+    xs = [float(line[30:38]) for line in text.splitlines() if line.startswith(("ATOM", "HETATM"))]
+    assert len(xs) == 2 * n_atoms
+
+
+def test_wrap_frames_pbc_no_box_is_identity():
+    info = {"box_lengths": None}
+    frames = np.random.default_rng(0).standard_normal((1, 5, 3))
+    np.testing.assert_array_equal(wrap_frames_pbc(frames, info), frames)

--- a/tests/test_openmm_engine.py
+++ b/tests/test_openmm_engine.py
@@ -1,0 +1,96 @@
+"""Real OpenMM (CPU platform) validation of the engine adapter + core driver.
+
+Builds a tiny system (a few particles in a harmonic well) so the full in-process
+path runs in well under a second on CPU, with no GPU required.  Skipped if
+OpenMM is not installed.
+"""
+
+import numpy as np
+import pytest
+
+openmm = pytest.importorskip("openmm")
+from openmm import (  # noqa: E402
+    CustomExternalForce,
+    LangevinMiddleIntegrator,
+    Platform,
+    System,
+    VerletIntegrator,
+    unit,
+)
+from openmm.app import Simulation, Topology  # noqa: E402
+
+from pathgennie.backends.openmm.engine import OpenMMEngine  # noqa: E402
+from pathgennie.backends.openmm.pg_omm import PathGennieMD  # noqa: E402
+
+
+def _build_simulation(n_particles=3, integrator="langevin"):
+    system = System()
+    for _ in range(n_particles):
+        system.addParticle(12.0 * unit.amu)
+    # Soft harmonic well centred at the origin so dynamics stay bounded.
+    force = CustomExternalForce("0.5*k*(x*x + y*y + z*z)")
+    force.addGlobalParameter("k", 10.0)
+    for i in range(n_particles):
+        force.addParticle(i, [])
+    system.addForce(force)
+
+    topology = Topology()
+    chain = topology.addChain()
+    residue = topology.addResidue("X", chain)
+    for _ in range(n_particles):
+        topology.addAtom("C", None, residue)
+
+    if integrator == "verlet":
+        integ = VerletIntegrator(0.002 * unit.picoseconds)
+    else:
+        integ = LangevinMiddleIntegrator(
+            300.0 * unit.kelvin, 1.0 / unit.picosecond, 0.002 * unit.picoseconds
+        )
+    sim = Simulation(topology, system, integ, Platform.getPlatformByName("CPU"))
+    return sim, n_particles
+
+
+def _positions(n):
+    return [[0.0, 0.0, 0.0] for _ in range(n)] * unit.nanometer
+
+
+def test_openmm_engine_segment_roundtrip():
+    sim, n = _build_simulation()
+    engine = OpenMMEngine(sim, temperature=300.0)
+    h0 = engine.create_state(_positions(n))
+    coords0 = engine.get_coords(h0)
+    assert coords0.shape == (n, 3)
+
+    h1 = engine.clone_anchor(h0)
+    h2 = engine.run_segment(h1, 5, randomize_velocities=True, seed=1)
+    coords2 = engine.get_coords(h2)
+    assert coords2.shape == (n, 3)
+    assert np.all(np.isfinite(coords2))
+    # Original snapshot is untouched by stepping the clone.
+    np.testing.assert_allclose(engine.get_coords(h0), coords0)
+
+
+def test_openmm_engine_run_reproducible():
+    # Deterministic integrator (Verlet): all remaining randomness (velocity
+    # draws + selection) is driven by the driver's seeded RNG, so the run is
+    # bit-reproducible. NOTE: with a stochastic Langevin integrator the
+    # thermostat noise stream is not per-segment reseedable in OpenMM, so only
+    # the driver-level decisions are reproducible there.
+    def run_once():
+        sim, n = _build_simulation(integrator="verlet")
+        runner = PathGennieMD(
+            simulation=sim,
+            projection_fn=lambda c: np.array([c[0, 0]]),
+            mode="escape",
+            convergence_fn=lambda c, **k: abs(c[0, 0]) > 50.0,  # never converges here
+            temperature=300.0,
+            sigma=0.1,
+            seed=2024,
+        )
+        return runner.run(_positions(n), tau1=3, tau2=5, max_trial=6, max_cycle=20, save_freq=2, verbosity=0)
+
+    traj_a, metrics_a = run_once()
+    traj_b, metrics_b = run_once()
+    assert traj_a.shape[0] >= 1
+    np.testing.assert_allclose(metrics_a, metrics_b)
+    np.testing.assert_allclose(traj_a, traj_b)

--- a/tests/test_opes.py
+++ b/tests/test_opes.py
@@ -1,0 +1,87 @@
+"""OPES tests: PLUMED input generation + verifiable toy-core FES recovery."""
+
+import numpy as np
+
+from pathgennie.core.toy import ToyLangevinEngine, wolfe_quapp_gradient, wolfe_quapp_potential
+from pathgennie.sampling import build_path_ensemble
+from pathgennie.sampling.opes import OPESBias, OPESSimulation, OPESStage, build_plumed_opes_input
+
+
+def test_build_plumed_opes_input_contains_actions():
+    text = build_plumed_opes_input(
+        ["phi: TORSION ATOMS=5,7,9,15", "psi: TORSION ATOMS=7,9,15,17"],
+        ["phi", "psi"],
+        pace=500, barrier=40.0, temp=300.0, sigma=[0.1, 0.1],
+    )
+    assert "OPES_METAD" in text
+    assert "ARG=phi,psi" in text
+    assert "PACE=500" in text
+    assert "BARRIER=40.0" in text
+    assert "TORSION ATOMS=5,7,9,15" in text
+    assert "opes.bias" in text
+
+
+def test_opes_bias_deposits_and_flattens():
+    bias = OPESBias(kT=1.0, gamma=10.0, sigma=0.2, barrier=8.0)
+    assert bias.bias(0.0) == bias.bias(0.0)  # no kernels -> floor, well-defined
+    for _ in range(50):
+        bias.update(0.0)
+    # After depositing at 0, the bias there should be higher (less negative) than
+    # at a far, never-visited point.
+    assert bias.bias(0.0) > bias.bias(3.0)
+    assert len(bias.centers) == 50
+
+
+def _analytic_marginal(grid, kT):
+    x = np.linspace(-2.5, 2.5, 2001)
+    trapz = getattr(np, "trapezoid", None) or np.trapz
+    fe = np.array([-kT * np.log(trapz(np.exp(-np.array([wolfe_quapp_potential(xi, y) for xi in x]) / kT), x))
+                   for y in grid])
+    return fe - fe.min()
+
+
+def test_opes_simulation_recovers_wq_marginal():
+    kT = 2.0
+    grid = np.linspace(-2.0, 2.0, 33)
+    bias = OPESBias(kT=kT, gamma=15.0, sigma=0.2, barrier=8.0)
+    sim = OPESSimulation(wolfe_quapp_gradient, cv_axis=1, kT=kT, dt=0.005, pace=20, bias=bias, seed=0)
+    samples = sim.run(np.array([-1.0, -1.4]), n_steps=20000)
+    fe = sim.fes(samples, grid)
+
+    finite = np.isfinite(fe)
+    # FES minimum should land in a basin (|y| ~ 1.4), not the central barrier.
+    assert abs(grid[finite][np.argmin(fe[finite])]) > 0.7
+    # Correlated with the analytic marginal over occupied bins.
+    an = _analytic_marginal(grid, kT)
+    corr = np.corrcoef(fe[finite] - fe[finite].min(), an[finite] - an[finite].min())[0, 1]
+    assert corr > 0.6
+
+
+def test_opes_stage_toy_mode_end_to_end():
+    engine = ToyLangevinEngine(dt=0.005, kT=2.0)
+    initial = engine.create_state((-1.0, -1.4))
+    # A tiny ensemble just to seed the stage with a starting configuration.
+    frames = np.array([engine.get_coords(initial)])
+    ens = build_path_ensemble(frames, np.array([0.0]), cv_fn=lambda c: c[0, 1])
+    stage = OPESStage(
+        mode="toy", potential_grad=wolfe_quapp_gradient, cv_axis=1,
+        grid=np.linspace(-2.0, 2.0, 25), n_steps=6000, pace=20,
+        gamma=15.0, sigma=0.2, barrier=8.0, kT=2.0, seed=1,
+    )
+    result = stage.run(ens, engine)
+    assert result.free_energy.shape == (25,)
+    assert result.metadata["n_kernels"] > 0
+
+
+def test_opes_plumed_mode_requires_capable_engine():
+    stage = OPESStage(
+        mode="plumed",
+        plumed_cv_definitions=["phi: TORSION ATOMS=5,7,9,15"],
+        plumed_arg_names=["phi"],
+    )
+    ens = build_path_ensemble(np.zeros((1, 3, 3)), np.array([0.0]))
+    try:
+        stage.run(ens, engine=object())  # no run_plumed -> informative error
+        assert False, "expected NotImplementedError"
+    except NotImplementedError:
+        pass

--- a/tests/test_path_sampling.py
+++ b/tests/test_path_sampling.py
@@ -1,0 +1,103 @@
+"""OpenPathSampling bridge tests.
+
+The dependency-free seed preparation is fully verified; the OPS-dependent stage
+is verified only to fail informatively when OpenPathSampling is absent (it is not
+installed in CI).
+"""
+
+import numpy as np
+
+from pathgennie.sampling import (
+    PathSamplingStage,
+    build_path_ensemble,
+    make_stage,
+)
+from pathgennie.sampling.path_sampling import (
+    CVRangeState,
+    extract_transition_path,
+    is_reactive,
+    label_frames,
+    prepare_ops_seed,
+    tis_interfaces,
+)
+
+
+def _frames(ys):
+    return np.array([[[0.0, y, 0.0]] for y in ys], dtype=float)
+
+
+CV = lambda c: c[0, 1]
+A = CVRangeState("A", -2.0, -1.0)
+B = CVRangeState("B", 1.0, 2.0)
+
+
+def test_cv_range_state_contains():
+    assert A.contains(-1.5) and not A.contains(0.0)
+    assert B.contains(1.5) and not B.contains(-1.5)
+
+
+def test_label_frames():
+    labels = label_frames(_frames([-1.5, 0.0, 1.5]), CV, A, B)
+    assert list(labels) == [0, -1, 1]   # A, none, B
+
+
+def test_extract_transition_path():
+    frames = _frames([-1.5, -1.4, -0.5, 0.2, 0.9, 1.5, 1.6])
+    span = extract_transition_path(frames, CV, A, B)
+    assert span == (1, 5)               # last A before first B .. first B
+    assert is_reactive(frames, CV, A, B)
+
+
+def test_not_reactive_paths():
+    assert extract_transition_path(_frames([-1.5, -1.4, -0.5]), CV, A, B) is None  # never reaches B
+    assert extract_transition_path(_frames([0.2, 0.9, 1.5]), CV, A, B) is None      # never in A first
+
+
+def test_tis_interfaces():
+    lin = tis_interfaces(-1.0, 1.0, 5, spacing="linear")
+    assert lin.shape == (5,)
+    assert np.all(np.diff(lin) > 0) and lin[0] == -1.0 and lin[-1] == 1.0
+    exp = tis_interfaces(-1.0, 1.0, 5, spacing="exp")
+    assert np.all(np.diff(exp) > 0) and np.isclose(exp[0], -1.0) and np.isclose(exp[-1], 1.0)
+    assert tis_interfaces(0.0, 1.0, 1).shape == (1,)
+    for bad in (lambda: tis_interfaces(1.0, 0.0, 3), lambda: tis_interfaces(0.0, 1.0, 0)):
+        try:
+            bad(); assert False
+        except ValueError:
+            pass
+
+
+def test_prepare_ops_seed():
+    frames = _frames([-1.5, -1.4, -0.5, 0.2, 0.9, 1.5, 1.6])
+    ens = build_path_ensemble(frames, np.arange(len(frames), dtype=float))
+    seed = prepare_ops_seed(ens, CV, A, B, interfaces=[-0.5, 0.0, 0.5])
+    assert seed["reactive"] and seed["span"] == (1, 5)
+    assert seed["seed_frames"].shape == (5, 1, 3)
+    assert seed["cv_trajectory"].shape == (7,)
+    assert list(seed["interfaces"]) == [-0.5, 0.0, 0.5]
+
+
+def test_make_stage_tps_tis():
+    tps = make_stage("tps", cv_fn=CV, state_a=(-2, -1), state_b=(1, 2))
+    assert isinstance(tps, PathSamplingStage) and tps.mode == "tps"
+    tis = make_stage("tis", cv_fn=CV, state_a=(-2, -1), state_b=(1, 2), interfaces=[-1, 0, 1])
+    assert isinstance(tis, PathSamplingStage) and tis.mode == "tis"
+
+
+def test_tis_requires_interfaces():
+    try:
+        PathSamplingStage(CV, state_a=(-2, -1), state_b=(1, 2), mode="tis")
+        assert False, "expected ValueError"
+    except ValueError:
+        pass
+
+
+def test_run_without_ops_raises_importerror():
+    frames = _frames([-1.5, -1.4, -0.5, 0.2, 0.9, 1.5, 1.6])
+    ens = build_path_ensemble(frames, np.arange(len(frames), dtype=float))
+    stage = PathSamplingStage(CV, state_a=(-2, -1), state_b=(1, 2), mode="tps")
+    try:
+        stage.run(ens, engine=None)
+        assert False, "expected ImportError (OpenPathSampling not installed)"
+    except ImportError as exc:
+        assert "OpenPathSampling" in str(exc)

--- a/tests/test_roadmap.py
+++ b/tests/test_roadmap.py
@@ -1,0 +1,63 @@
+"""Roadmap graph + pathway extraction tests (pure standard library / NumPy)."""
+
+import math
+
+from pathgennie.search.roadmap import Roadmap, dijkstra_path, k_shortest_paths
+
+
+def test_dijkstra_simple():
+    adj = {
+        "A": {"B": 1.0, "C": 4.0},
+        "B": {"C": 1.0, "D": 5.0},
+        "C": {"D": 1.0},
+        "D": {},
+    }
+    cost, path = dijkstra_path(adj, "A", "D")
+    assert path == ["A", "B", "C", "D"]
+    assert math.isclose(cost, 3.0)
+
+
+def test_dijkstra_unreachable():
+    adj = {"A": {"B": 1.0}, "B": {}, "C": {}}
+    cost, path = dijkstra_path(adj, "A", "C")
+    assert cost == math.inf and path == []
+
+
+def test_k_shortest_paths_distinct_increasing():
+    adj = {
+        "A": {"B": 1.0, "C": 1.0},
+        "B": {"D": 1.0},
+        "C": {"D": 1.0},
+        "D": {},
+    }
+    paths = k_shortest_paths(adj, "A", "D", k=2)
+    assert len(paths) == 2
+    costs = [c for c, _ in paths]
+    assert costs[0] <= costs[1]
+    # Two genuinely different parallel routes A->B->D and A->C->D.
+    route_sets = {tuple(p) for _, p in paths}
+    assert route_sets == {("A", "B", "D"), ("A", "C", "D")}
+
+
+def test_roadmap_from_sequence_and_min_path():
+    rm = Roadmap()
+    # State trajectory visiting 0 -> 1 -> 2 mostly, with a rare 0 -> 2 jump.
+    seq = [0, 0, 1, 1, 2, 2, 1, 0, 1, 2, 0, 2]
+    rm.observe_sequence(seq)
+    assert set(rm.nodes) == {0, 1, 2}
+
+    adj = rm.adjacency()
+    # The frequent 0->1 edge must be cheaper than the rare 0->2 edge.
+    assert adj[0][1] < adj[0][2]
+
+    cost, path = rm.min_free_energy_path(0, 2)
+    assert path[0] == 0 and path[-1] == 2
+    assert cost < math.inf
+
+
+def test_roadmap_all_pairs_report():
+    rm = Roadmap()
+    rm.observe_sequence([0, 1, 2, 1, 0, 1, 2])
+    report = rm.all_pairs_paths(k=1)
+    assert (0, 2) in report
+    assert report[(0, 2)][0][1][0] == 0

--- a/tests/test_rrt.py
+++ b/tests/test_rrt.py
@@ -1,0 +1,69 @@
+"""RRT / RRT-Connect search tests on the toy Wolfe-Quapp engine (pure NumPy)."""
+
+import numpy as np
+
+from pathgennie.core.parallel import SerialExecutor
+from pathgennie.core.toy import ToyLangevinEngine
+from pathgennie.search.rrt import RRT, rrt_connect
+
+
+def _xy(coords):
+    return np.array([coords[0, 0], coords[0, 1]])
+
+
+# WQ minima sit near (-1.17, 1.48) and (1.12, -1.48).
+BASIN_A = (-1.174, 1.477)
+BASIN_B = (1.124, -1.485)
+
+
+def test_rrt_reaches_target_basin():
+    engine = ToyLangevinEngine(dt=0.005, kT=1.0)
+    start = engine.create_state(BASIN_A)
+    rrt = RRT(
+        engine, _xy, lower=[-2.0, -2.0], upper=[2.0, 2.0],
+        tau1=5, tau2=10, n_expand=8, sigma=0.05, goal_bias=0.2,
+        executor=SerialExecutor(), seed=0,
+    )
+    result = rrt.build(start, target_cv=list(BASIN_B), max_iter=300, goal_tol=0.5)
+
+    assert result.tree_size > 1
+    assert result.success, "RRT should reach the opposite basin"
+    # Path starts in basin A and ends near basin B.
+    assert np.linalg.norm(result.path[0].cv - np.array(BASIN_A)) < 0.8
+    assert np.linalg.norm(result.path[-1].cv - np.array(BASIN_B)) <= 0.5
+    # Path nodes form a parent chain.
+    for child in result.path[1:]:
+        assert child.parent is not None
+
+
+def test_rrt_grows_tree_without_target():
+    engine = ToyLangevinEngine(dt=0.005, kT=1.0)
+    start = engine.create_state(BASIN_A)
+    rrt = RRT(
+        engine, _xy, lower=[-2.0, -2.0], upper=[2.0, 2.0],
+        tau1=4, tau2=8, n_expand=6, executor=SerialExecutor(), seed=1,
+    )
+    result = rrt.build(start, target_cv=None, max_iter=40)
+    assert result.tree_size == 41  # root + 40 expansions
+    # The tree should have explored beyond the start basin.
+    cvs = np.stack([n.cv for n in rrt.nodes])
+    assert cvs[:, 0].max() - cvs[:, 0].min() > 0.5
+
+
+def test_rrt_connect_links_two_basins():
+    engine = ToyLangevinEngine(dt=0.005, kT=1.0)
+    start = engine.create_state(BASIN_A)
+    goal = engine.create_state(BASIN_B)
+    result = rrt_connect(
+        engine, _xy, start, goal,
+        lower=[-2.0, -2.0], upper=[2.0, 2.0],
+        tau1=5, tau2=10, n_expand=8, sigma=0.05,
+        executor=SerialExecutor(), seed=2, max_iter=300, connect_tol=0.6,
+    )
+    assert result.success
+    assert len(result.path) >= 2
+    endpoints = np.array([result.path[0].cv, result.path[-1].cv])
+    # One endpoint near each basin (order may vary by which tree was 'start').
+    near_a = min(np.linalg.norm(endpoints - np.array(BASIN_A), axis=1))
+    near_b = min(np.linalg.norm(endpoints - np.array(BASIN_B), axis=1))
+    assert near_a < 0.8 and near_b < 0.8

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -1,0 +1,48 @@
+import numpy as np
+import pytest
+
+from pathgennie.core.selection import selection_probs, softmax_select
+
+
+def test_probs_sum_to_one():
+    probs = selection_probs(np.array([0.1, 0.5, 0.9, 0.3]), sigma=0.2)
+    assert probs.shape == (4,)
+    assert np.isclose(probs.sum(), 1.0)
+    assert np.all(probs >= 0)
+
+
+def test_degenerate_batch_is_uniform():
+    probs = selection_probs(np.array([2.0, 2.0, 2.0]), sigma=0.1)
+    assert np.allclose(probs, 1.0 / 3.0)
+
+
+def test_small_sigma_approaches_argmax():
+    metrics = np.array([0.0, 0.2, 1.0, 0.5])
+    probs = selection_probs(metrics, sigma=1e-3)
+    assert probs.argmax() == metrics.argmax()
+    assert probs[metrics.argmax()] > 0.99
+
+
+def test_large_sigma_approaches_uniform():
+    metrics = np.array([0.0, 0.5, 1.0])
+    probs = selection_probs(metrics, sigma=1e6)
+    assert np.allclose(probs, 1.0 / 3.0, atol=1e-3)
+
+
+def test_softmax_select_is_reproducible():
+    metrics = np.array([0.1, 0.9, 0.4, 0.7])
+    a = softmax_select(metrics, 0.3, np.random.default_rng(123))
+    b = softmax_select(metrics, 0.3, np.random.default_rng(123))
+    assert a == b
+    assert 0 <= a < metrics.size
+
+
+@pytest.mark.parametrize("bad_sigma", [0.0, -1.0])
+def test_invalid_sigma_raises(bad_sigma):
+    with pytest.raises(ValueError):
+        selection_probs(np.array([1.0, 2.0]), sigma=bad_sigma)
+
+
+def test_nonfinite_metrics_raise():
+    with pytest.raises(ValueError):
+        selection_probs(np.array([1.0, np.nan]), sigma=0.1)

--- a/tests/test_smoke_langevin.py
+++ b/tests/test_smoke_langevin.py
@@ -1,0 +1,77 @@
+"""Full-driver smoke + reference tests on the toy Wolfe-Quapp engine.
+
+These exercise the entire adaptive cycle (swarm -> selection -> runner ->
+convergence) with no MD binary or GPU, so they run in CI in well under a second
+while still reproducing the paper's two-minima Wolfe-Quapp behaviour.
+"""
+
+import numpy as np
+
+from pathgennie.core.driver import PathGennieDriver
+from pathgennie.core.parallel import SerialExecutor, ThreadDevicePool
+from pathgennie.core.progress import TargetMetric
+from pathgennie.core.toy import ToyLangevinEngine, wolfe_quapp_gradient
+
+# Wolfe-Quapp minima (numerical stationary points of the potential below).
+SOURCE = (-1.174, 1.477)
+TARGET = np.array([1.124, -1.485])
+
+
+def _xy(coords):
+    return np.array([coords[0, 0], coords[0, 1]])
+
+
+def test_minima_are_stationary_points():
+    # Sanity check the potential: gradient should be near zero at the minima.
+    assert np.linalg.norm(wolfe_quapp_gradient(np.array(SOURCE))) < 1.0
+    assert np.linalg.norm(wolfe_quapp_gradient(TARGET)) < 1.0
+
+
+def _make_driver(executor, seed):
+    engine = ToyLangevinEngine(dt=0.005, kT=1.0, gamma=1.0)
+    initial = engine.create_state(SOURCE)
+    progress = TargetMetric(_xy, target_cv=TARGET)
+
+    def converged(coords):
+        return bool(np.linalg.norm(_xy(coords) - TARGET) < 0.5)
+
+    driver = PathGennieDriver(
+        engine, progress, converged,
+        executor=executor, sigma=0.1, seed=seed, verbosity=0,
+    )
+    return driver, initial
+
+
+def test_driver_reaches_target():
+    driver, initial = _make_driver(SerialExecutor(), seed=7)
+    traj, metrics = driver.run(
+        initial, tau1=20, tau2=40, max_trial=16, max_cycle=400, save_freq=5
+    )
+    assert traj.shape[0] >= 1
+    assert traj.shape[1:] == (1, 3)
+    # The last saved frame should be at (or past) the target basin.
+    assert np.linalg.norm(_xy(traj[-1]) - TARGET) < 0.8
+    # Metric (negated distance to target) should improve overall.
+    assert metrics[-1] > metrics[0]
+
+
+def test_serial_equals_threadpool_single_device():
+    """A device pool with one slot must match serial output for a fixed seed."""
+    d1, i1 = _make_driver(SerialExecutor(), seed=42)
+    t1, m1 = d1.run(i1, tau1=15, tau2=30, max_trial=8, max_cycle=120, save_freq=5)
+
+    d2, i2 = _make_driver(ThreadDevicePool(devices=[0]), seed=42)
+    t2, m2 = d2.run(i2, tau1=15, tau2=30, max_trial=8, max_cycle=120, save_freq=5)
+
+    np.testing.assert_allclose(m1, m2)
+    assert t1.shape == t2.shape
+    np.testing.assert_allclose(t1, t2)
+
+
+def test_round_robin_device_assignment():
+    """ThreadDevicePool spreads work items across devices in order."""
+    pool = ThreadDevicePool(devices=[0, 1, 2, 3])
+    seen = pool.map(lambda item, device: (item, device), list(range(8)))
+    # Items preserve order and devices cycle 0,1,2,3,0,1,2,3.
+    assert [s[0] for s in seen] == list(range(8))
+    assert [s[1] for s in seen] == [0, 1, 2, 3, 0, 1, 2, 3]

--- a/tests/test_spib.py
+++ b/tests/test_spib.py
@@ -1,0 +1,87 @@
+"""SPIB data-driven CV tests (skipped if PyTorch is unavailable)."""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("torch")
+
+from pathgennie.core.driver import PathGennieDriver  # noqa: E402
+from pathgennie.core.parallel import SerialExecutor  # noqa: E402
+from pathgennie.core.progress import TargetMetric  # noqa: E402
+from pathgennie.core.toy import ToyLangevinEngine  # noqa: E402
+from pathgennie.cv.features import Featurizer  # noqa: E402
+from pathgennie.cv.spib import SPIBProgress, kmeans_labels, train_spib  # noqa: E402
+
+
+def _two_state_trajectory(n=600, seed=0):
+    rng = np.random.default_rng(seed)
+    states = [0]
+    for _ in range(1, n):
+        states.append(states[-1] if rng.random() < 0.95 else 1 - states[-1])
+    states = np.array(states)
+    centers = np.array([[-3.0, 0.0], [3.0, 0.0]])
+    feats = centers[states] + 0.3 * rng.standard_normal((n, 2))
+    return feats, states
+
+
+def test_kmeans_separates_clusters():
+    feats, gt = _two_state_trajectory()
+    labels = kmeans_labels(feats, k=2, seed=0)
+    acc = max((labels == gt).mean(), (labels == 1 - gt).mean())
+    assert acc > 0.95
+
+
+def test_spib_recovers_two_states():
+    feats, gt = _two_state_trajectory()
+    res = train_spib(
+        feats, dt=1, n_states_init=4, latent_dim=1,
+        beta=1e-3, epochs=40, n_refine=4, seed=0,
+    )
+    # Emergent number of metastable states should be 2 (started from 4).
+    assert 2 <= res.n_states <= 4
+
+    # The learned latent should separate the two ground-truth basins.
+    import torch
+    x = (feats - res.feature_mean) / res.feature_std
+    with torch.no_grad():
+        z = res.model.encode(torch.tensor(x, dtype=torch.float32))[0].numpy().ravel()
+    sep = abs(z[gt == 0].mean() - z[gt == 1].mean())
+    pooled = z.std() + 1e-9
+    assert sep / pooled > 1.5
+
+    acc = max((res.labels == gt).mean(), (res.labels == 1 - gt).mean())
+    assert acc > 0.85
+
+
+def test_spib_progress_drives_and_switches_to_learned_cv():
+    engine = ToyLangevinEngine(dt=0.005)
+    initial = engine.create_state((-1.174, 1.477))
+    target = np.array([[1.124, -1.485, 0.0]])
+
+    def xy(coords):
+        return np.array([coords[0, 0], coords[0, 1]])
+
+    bootstrap = TargetMetric(xy, target_cv=np.array([1.124, -1.485]))
+    progress = SPIBProgress(
+        Featurizer(funcs=[], standardize=False),
+        bootstrap,
+        mode="target",
+        target_coords=target,
+        refresh_every=15,
+        min_frames=30,
+        dt=1,
+        train_kwargs=dict(n_states_init=3, latent_dim=1, epochs=15, n_refine=2, seed=0),
+    )
+
+    driver = PathGennieDriver(
+        engine, progress, convergence_fn=lambda c: False,
+        executor=SerialExecutor(), sigma=0.2, seed=1, verbosity=0,
+    )
+    traj, metrics = driver.run(initial, tau1=10, tau2=20, max_trial=6, max_cycle=50, save_freq=5)
+
+    # SPIB trained on the fly and the CV is now the learned latent.
+    assert progress.result is not None
+    assert progress.n_states is not None and progress.n_states >= 1
+    learned_cv = progress.project(engine.get_coords(initial))
+    assert learned_cv.shape == (1,)  # latent_dim
+    assert traj.shape[0] >= 1

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -1,0 +1,63 @@
+import logging
+
+import numpy as np
+
+from pathgennie.core.strategy import (
+    DISCOVERY,
+    SAMPLING,
+    check_learned_cv_segment_length,
+    get_profile,
+    resolve_profile,
+)
+from pathgennie.sampling import PathEnsemble, SamplingResult, SamplingStage
+
+
+def test_no_profile_passthrough():
+    cfg = {"tau1_steps": 2, "max_trial": 7}
+    assert resolve_profile(cfg) == cfg
+
+
+def test_profile_fills_defaults():
+    resolved = resolve_profile({"profile": "discovery"})
+    assert resolved["tau1_steps"] == DISCOVERY.tau1_steps
+    assert resolved["cv"] == "geometric"
+    assert resolved["downstream"] is None
+
+
+def test_explicit_overrides_profile():
+    resolved = resolve_profile({"profile": "sampling", "tau1_steps": 5})
+    assert resolved["tau1_steps"] == 5            # explicit wins
+    assert resolved["cv"] == SAMPLING.cv           # profile default kept
+    assert resolved["downstream"] == "weighted_ensemble"
+
+
+def test_get_profile_unknown_raises():
+    try:
+        get_profile("nope")
+        assert False, "expected KeyError"
+    except KeyError:
+        pass
+
+
+def test_learned_cv_segment_guard(caplog):
+    # 2+8 steps * 0.002 ps = 0.02 ps < 0.1 ps -> warn, return False.
+    with caplog.at_level(logging.WARNING):
+        ok = check_learned_cv_segment_length(2, 8, 0.002, min_ps=0.1)
+    assert ok is False
+    assert any("Learned CV" in rec.message for rec in caplog.records)
+    # 50+100 steps * 0.002 ps = 0.3 ps -> fine.
+    assert check_learned_cv_segment_length(50, 100, 0.002, min_ps=0.1) is True
+
+
+def test_path_ensemble_and_stage_contract():
+    frames = np.zeros((3, 4, 3))
+    ens = PathEnsemble(frames=frames, metrics=np.arange(3.0))
+    assert ens.n_frames == 3
+
+    class DummyStage:
+        def run(self, ensemble, engine, **kwargs):
+            return SamplingResult(metadata={"n": ensemble.n_frames})
+
+    stage = DummyStage()
+    assert isinstance(stage, SamplingStage)  # structural Protocol check
+    assert stage.run(ens, engine=None).metadata["n"] == 3

--- a/tests/test_weighted_ensemble.py
+++ b/tests/test_weighted_ensemble.py
@@ -143,9 +143,7 @@ def test_we_recycling_produces_finite_rate():
     np.testing.assert_allclose(result.metadata["weight_trace"], 1.0, atol=1e-9)
 
 
-def test_make_stage_opes_not_implemented():
-    try:
-        make_stage("opes")
-        assert False, "expected NotImplementedError"
-    except NotImplementedError:
-        pass
+def test_make_stage_builds_opes():
+    from pathgennie.sampling.opes import OPESStage
+    stage = make_stage("opes", mode="toy", cv_axis=1)
+    assert isinstance(stage, OPESStage)

--- a/tests/test_weighted_ensemble.py
+++ b/tests/test_weighted_ensemble.py
@@ -1,0 +1,151 @@
+"""Weighted Ensemble stage tests (pure NumPy: no torch, no MD binary)."""
+
+import numpy as np
+
+from pathgennie.core.driver import PathGennieDriver
+from pathgennie.core.parallel import SerialExecutor
+from pathgennie.core.progress import EscapeMetric
+from pathgennie.core.toy import ToyLangevinEngine, wolfe_quapp_potential
+from pathgennie.sampling import (
+    GridBinner,
+    PathEnsemble,
+    Walker,
+    WeightedEnsembleStage,
+    build_path_ensemble,
+    make_stage,
+    resample,
+)
+
+
+# --------------------------------------------------------------------------- #
+# resample (split/merge)
+# --------------------------------------------------------------------------- #
+def _clone_release_stubs():
+    store = {"next": 0, "alive": set()}
+
+    def clone(handle):
+        store["next"] += 1
+        h = ("clone", store["next"])
+        store["alive"].add(h)
+        return h
+
+    def release(handle):
+        store["alive"].discard(handle)
+
+    return clone, release, store
+
+
+def test_resample_split_conserves_weight_and_count():
+    rng = np.random.default_rng(0)
+    clone, release, _ = _clone_release_stubs()
+    walkers = [Walker(handle=i, weight=w, bin=0) for i, w in enumerate([0.1, 0.2, 0.7])]
+    out = resample(walkers, target_count=4, rng=rng, clone_fn=clone, release_fn=release)
+    assert len(out) == 4
+    assert abs(sum(w.weight for w in out) - 1.0) < 1e-12
+
+
+def test_resample_merge_conserves_weight_and_count():
+    rng = np.random.default_rng(0)
+    clone, release, _ = _clone_release_stubs()
+    weights = [0.05, 0.05, 0.1, 0.3, 0.5]
+    walkers = [Walker(handle=i, weight=w, bin=0) for i, w in enumerate(weights)]
+    out = resample(walkers, target_count=2, rng=rng, clone_fn=clone, release_fn=release)
+    assert len(out) == 2
+    assert abs(sum(w.weight for w in out) - 1.0) < 1e-12
+
+
+# --------------------------------------------------------------------------- #
+# GridBinner
+# --------------------------------------------------------------------------- #
+def test_grid_binner_edges_and_indices():
+    binner = GridBinner.from_values([-2.0, 2.0], n_bins=4, pad=0.0)
+    assert binner.n_bins == 4
+    assert np.all(np.diff(binner.edges) > 0)
+    assert binner.bin_index(-2.0) == 0
+    assert binner.bin_index(2.0) == 3
+    assert binner.bin_index(-100.0) == 0   # clamp low
+    assert binner.bin_index(100.0) == 3    # clamp high
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end WE on the toy Wolfe-Quapp engine
+# --------------------------------------------------------------------------- #
+def _toy_path_ensemble(seed=0):
+    """Produce a PathEnsemble spanning the WQ y-axis from a short toy run."""
+    engine = ToyLangevinEngine(dt=0.005, kT=2.0)
+    initial = engine.create_state((-1.0, -1.4))
+
+    def y_cv(coords):
+        return np.array([coords[0, 1]])
+
+    progress = EscapeMetric(y_cv, start_cv=np.array([-1.4]), escape_metric="cv0")
+    driver = PathGennieDriver(
+        engine, progress, convergence_fn=lambda c: False,
+        executor=SerialExecutor(), sigma=0.3, seed=seed, verbosity=0,
+    )
+    traj, metrics, handles = driver.run(
+        initial, tau1=5, tau2=10, max_trial=5, max_cycle=40, save_freq=2,
+        collect_seeds=True,
+    )
+    ens = build_path_ensemble(traj, metrics, handles=handles, cv_fn=lambda c: c[0, 1])
+    return engine, ens
+
+
+def test_we_conserves_weight_and_balances_bins():
+    engine, ens = _toy_path_ensemble()
+    stage = WeightedEnsembleStage(
+        cv_fn=lambda c: c[0, 1], tau_steps=5, n_iterations=15,
+        n_bins=8, target_count=4, seed=1,
+    )
+    result = stage.run(ens, engine)
+
+    # Total weight conserved every iteration and at the end.
+    np.testing.assert_allclose(result.metadata["weight_trace"], 1.0, atol=1e-9)
+    assert abs(result.weights.sum() - 1.0) < 1e-9
+    # Each surviving walker lives in a bin balanced to target_count.
+    assert result.weights.size % 4 == 0
+
+
+def test_we_recovers_fes_minimum_in_a_basin():
+    engine, ens = _toy_path_ensemble()
+    stage = WeightedEnsembleStage(
+        cv_fn=lambda c: c[0, 1], tau_steps=8, n_iterations=60,
+        n_bins=10, target_count=4, seed=2, kT=2.0,
+    )
+    result = stage.run(ens, engine)
+
+    centers = result.metadata["bin_centers"]
+    fe = result.free_energy
+    finite = np.isfinite(fe)
+    min_center = centers[finite][np.argmin(fe[finite])]
+    # WQ minima sit near y ~ +/-1.4; the FES minimum should be in a basin,
+    # not at the central barrier (|y| ~ 0).
+    assert abs(min_center) > 0.7
+
+    # And the barrier region should be higher in free energy than the basin.
+    barrier_bins = finite & (np.abs(centers) < 0.4)
+    if barrier_bins.any():
+        assert np.min(fe[barrier_bins]) >= np.min(fe[finite]) - 1e-9
+
+
+def test_we_recycling_produces_finite_rate():
+    engine, ens = _toy_path_ensemble()
+    stage = make_stage(
+        "weighted_ensemble",
+        cv_fn=lambda c: c[0, 1], tau_steps=6, n_iterations=40,
+        n_bins=8, target_count=3, seed=3,
+        recycle=True, source_cv=-1.4, target_cv=1.2, timestep_ps=0.002,
+    )
+    result = stage.run(ens, engine)
+    assert result.rate_constants is not None
+    assert result.rate_constants["flux_per_iter"] >= 0.0
+    assert np.isfinite(result.rate_constants["rate"])
+    np.testing.assert_allclose(result.metadata["weight_trace"], 1.0, atol=1e-9)
+
+
+def test_make_stage_opes_not_implemented():
+    try:
+        make_stage("opes")
+        assert False, "expected NotImplementedError"
+    except NotImplementedError:
+        pass


### PR DESCRIPTION
Targets `devel` (to merge into `main` later).

## Summary
Re-architects PathGennie around a single backend-independent core and adds the
full feature roadmap on top. Existing `input.yaml` cases run unchanged.
**69 tests pass** (toy/synthetic-verified in a CPU-only environment).

## What's included
- **Shared core (`pathgennie/core/`)** — one `PathGennieDriver` (the cycle was
  duplicated across all 3 backends), with `Engine`/`ProgressVariable`/
  `ExplorerPolicy` protocols, centralized `softmax_select`, reproducible seeding,
  always-save-converged-frame, bounded scratch, and a pure-NumPy Wolfe–Quapp toy
  engine for CI.
- **True multi-GPU** — `ParallelExecutor`/`ThreadDevicePool`; device-aware AMBER &
  GROMACS engines export `CUDA_VISIBLE_DEVICES` per segment with isolated
  per-device scratch (fixing the old all-on-GPU-0 contention + filename races).
  New config: `devices`, `workers_per_device`, `seed`.
- **Data-driven CV (SPIB)** — `cv/features.py` + `cv/spib.py`; `SPIBProgress`
  learns a CV and emergent metastable states on the fly (optional `ml` extra).
- **Strategy profiles** — `discovery` vs `sampling` presets + learned-CV
  trajectory-length guard.
- **Non-linear search** — `search/rrt.py` (RRT / RRT-Connect) for pathways the
  greedy metric can't follow.
- **Roadmap + agent** — `search/roadmap.py` (Dijkstra + Yen k-shortest all-pairs
  pathways) and `agent/controller.py` (rule-based adaptive controller).
- **Weighted Ensemble** — path-informed `WeightedEnsembleStage` (free energies +
  rate constants), reusing the engine + device pool.
- **OPES via PLUMED** — `OPESStage` generates an `OPES_METAD` input and drives a
  PLUMED-capable engine, plus a CI-verified toy OPES core.
- **Downstream wiring** — `pathgennie.downstream` honoured by all three backends.
- **Docs & changelog** — full manual + 8 tutorials in `docs/`, `CHANGELOG.md`,
  version `0.2.0`.

## Caveats (documented in `docs/roadmap.md`)
Real-MD paths (multi-GPU AMBER/GROMACS, downstream stages on solvated systems,
and OPES needing a PLUMED-patched engine exposing `run_plumed`) are wired through
shared, tested helpers but cannot be executed in a CPU-only sandbox.

https://claude.ai/code/session_01BtxGQ8fFHgZXDdhWWAF9mS

---
_Generated by [Claude Code](https://claude.ai/code/session_01BtxGQ8fFHgZXDdhWWAF9mS)_